### PR TITLE
One shot entity

### DIFF
--- a/docs/API-post-registration.md
+++ b/docs/API-post-registration.md
@@ -1,0 +1,195 @@
+### Post-Registration
+
+Each path is preceded by the corresponding API URL, followed by an environment-specific path segment:
+Example:
+
+```
+https://u4k2uilit9.execute-api.us-east-2.amazonaws.com/dev
+```
+
+where `"u4k2uilit9.execute-api.us-east-2.amazonaws.com"` identifies the API gateway resource *(each role gets its own such resource)* and `"dev"` identifies the environment.
+
+- #### `/SYS_ADMIN`
+
+  All tasks that can be performed by the role of system administrator
+
+  - Allowed Methods: POST, GET, OPTIONS
+
+  - Path elements: NONE
+
+  - Headers:
+
+    - "Authorization": `Bearer ${JWT Access Token}`
+
+    - "Content-Type": "application/json"
+
+    - "ettpayload":
+
+      - Lookup a user and retrieve information about that user, including info about the entity the user belongs to and details about the other users who belong to that same entity.
+
+        ```
+        {
+          "task": "lookup-user-context",
+          "parameters": {
+          	"email": string,
+          	"role": string
+          }
+        }
+        ```
+
+        Returns:
+
+        ```
+        {
+        
+        }
+        ```
+
+      - Invite a user to an entity.
+
+        ```
+        {
+          "task": "invite-user",
+          "parameters": {
+          	"email": string,
+          	"role": string
+          }
+        }
+        ```
+
+        Returns:
+
+        ```
+        {
+          "message": string,
+          "parameters": {
+            "ok": true,
+            "invitation_code": string,
+            "invitation_link": string
+          }
+        }
+        
+        # Where invitation_link resembles: "https://duqvs0kd8d3vj.cloudfront.net?action=acknowledge&entity_id=__UNASSIGNED__&code=14e91df7-66a0-488a-b1ed-11da545c07bf"
+        ```
+
+      - Create an entity
+
+        ```
+        {
+          "task": "create-entity",
+          "parameters": {
+          	"email": string,
+          	"role": string
+          }
+        }
+        ```
+
+        Returns:
+
+        ```
+        {
+        
+        }
+        ```
+
+      - Update an entity
+
+        ```
+        {
+          "task": "update-entity",
+          "parameters": {
+          
+          }
+        }
+        ```
+
+        Returns:
+
+        ```
+        {
+        
+        }
+        ```
+
+      - Deactivate an entity
+
+        ```
+        {
+          "task": "",
+          "parameters": {
+          
+          }
+        }
+        ```
+
+        Returns:
+
+        ```
+        {
+        
+        }
+        ```
+
+        
+
+- #### `/RE_ADMIN`
+
+  All tasks that can be performed by the role of registered entity administrator
+
+  - Allowed Methods: POST, GET, OPTIONS
+
+  - Path elements: NONE
+
+  - Headers:
+
+    - "Authorization": `Bearer ${JWT Access Token}`
+
+    - "Content-Type": "application/json"
+
+    - "ettpayload":
+
+      - Lookup a user and retrieve information about that user, including info about the entity the user belongs to and details about the other users who belong to that same entity.
+
+        ```
+        {
+          "task": "lookup-user-context",
+          "parameters": {
+          	"email": string,
+          	"role": string
+          }
+        }
+        ```
+
+        Returns:
+
+        ```
+        {
+        
+        }
+        ```
+
+        
+
+- #### `/RE_AUTH_IND`
+
+  All tasks that can be performed by the role of authorized individual
+
+  - Allowed Methods: POST, GET, OPTIONS
+  - Path elements: NONE
+  - Headers:
+    - "Authorization": `Bearer ${JWT Access Token}`
+    - "Content-Type": "application/json"
+    - "ettpayload":
+
+- #### `/CONSENTING_PERSON`
+
+  All tasks that can be performed by the role of consenting person
+
+  - Allowed Methods: POST, GET, OPTIONS
+  - Path elements: NONE
+  - Headers:
+    - "Authorization": `Bearer ${JWT Access Token}`
+    - "Content-Type": "application/json"
+    - "ettpayload":
+
+

--- a/docs/API-pre-registration.md
+++ b/docs/API-pre-registration.md
@@ -1,0 +1,198 @@
+## Pre-Registration:
+
+Each path is preceded by the corresponding API URL, followed by an environment-specific path segment:
+Example:
+
+```
+https://u4k2uilit9.execute-api.us-east-2.amazonaws.com/dev
+```
+
+where `"u4k2uilit9.execute-api.us-east-2.amazonaws.com"` identifies the API gateway resource, `"dev"` identifies the environment.
+
+- #### `/acknowledge/{task}/{invitation-code}`
+
+  Acknowledgment of privacy policy is recorded for a user by "marking" their invitation dynamodb record accordingly.
+
+  - Allowed Methods: POST, GET, OPTIONS
+
+  - Path Elements:
+
+    - task: 
+
+      - "lookup-invitation":
+        Returns information about the invitation
+
+        ```
+        {
+          "message": "Ok",
+          "payload": {
+            "ok": "true", {
+              code: string,
+              role: Role,
+              email: string,
+              entity_id: string,
+              sent_timestamp: string,
+              message_id: string,
+              fullname?: string,
+              title?: string,
+              acknowledged_timestamp?: string,
+              consented_timestamp?: string,
+              retracted_timestamp?: string
+            }
+          }
+        }
+        ```
+
+      - "register"
+        Register acknowledgement of the privacy policy for the invited individual.
+        Returns as follows:
+
+        ```
+        { "message": "Ok: Acknowledgement registered for [invitation-code]" }
+        or...
+        { "message": "Ok: Already acknowledged at [timestamp]" }
+        ```
+
+    - invitation-code:
+
+  - Headers: NONE
+
+- #### `/consent/{task}/{invitation-code}`
+
+  Consent to the terms of ETT is recorded for a user by "marking" their invitation dynamodb record accordingly.
+
+  - Allowed Methods: POST, GET, OPTIONS
+
+  - Path Elements:
+
+    - task
+
+      - "lookup-invitation"
+        Returns information about the invitation
+
+        ```
+        {
+          "message": "Ok",
+          "payload": {
+            "ok": "true", {
+              code: string,
+              role: Role,
+              email: string,
+              entity_id: string,
+              sent_timestamp: string,
+              message_id: string,
+              fullname?: string,
+              title?: string,
+              acknowledged_timestamp?: string,
+              consented_timestamp?: string,
+              retracted_timestamp?: string
+            }
+          }
+        }
+        ```
+
+      - "lookup-entity"
+        Returns details about the entity
+
+        ```
+        {
+          "message": "Ok",
+          "payload": {
+          	"ok": "true", {
+          	  entity_id: string,
+              entity_name: string,
+              description: string,
+              create_timestamp?: string,
+              update_timestamp?: string,
+              active?: Y_or_N
+          	}
+          }
+        }
+        ```
+
+      - "register"
+        Register consent for the invited individual.
+        Returns as follows:
+
+        ```
+        { "message": "Ok: Consent registered for [invitation-code]" }
+        or...
+        { "message": "Ok: Already consented at [timestamp]" }
+        ```
+
+      - "terminate"
+        Delete the entity entirely. This results in:
+
+        1. The removal of all invitations to the entity that were sent from the database.
+        2. The removal of all users who belong to the entity from the database.
+        3. The removal of the entity record itself from the database.
+        4. The removal of every userpool entry associated with the entity from cognito
+
+        Querystring Parameters:
+
+        - notify: "true"*(default)*|"false"
+          Indicates emailing each individual who was connected to the entity informing them of its deletion.
+
+        Returns as follows, DeletionRecord:
+
+        ```
+        {
+          "databaseCommandInput": {
+            "TransactItems": [
+              {
+                "Delete": {
+                  "TableName": "ett-users",
+                  "Key": {
+                    "entity_id": {
+                      "S": "[entity-id]"
+                    },
+                    "email": {
+                      "S": "[email-address]"
+                    }
+                  }
+                }
+              },
+              more users...
+              },
+              {
+                "Delete": {
+                  "TableName": "ett-invitation",
+                  "Key": {
+                    "code": {
+                      "S": "[invitation-code]"
+                    }
+                  }
+                }
+              },
+              more invitations...
+              {
+                "Delete": {
+                  "TableName": "ett-entities",
+                  "Key": {
+                    "entity_id": {
+                      "S": "[entity-id]"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "deletedUsers": [
+            {
+              email: string,
+              entity_id: string,
+              sub: string,
+              role: Role,
+              fullname?: string,
+              title?: string,
+              phone_number?: string,
+              create_timestamp?: string,
+              update_timestamp?: string,
+              active?: Y_or_N
+            },
+            more users...
+          ]
+        }
+        ```
+
+        

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,26 @@
+## API Documentation
+
+The ETT application follows the convention of a single-page solution that loads most of its dynamic content through api calls to the "backend" to retrieve JSON payloads.
+
+Front-end developers can reference this document for api definitions available to them.
+
+These definitions fall into one of two initial categories:
+
+1. [**Pre-Registration**](./API-pre-registration.md)
+   These api endpoints are used during the registration process where the user has not yet established a cognito userpool presence for themselves, and hence will not yet be involving use of a JWT for authentication.
+   Most pre-registration endpoints include an "invitation-code" path element, and authentication involves an otherwise public api call that is backed by a lambda function that checks the invitation code for a match in the applications dynamodb database before proceeding with its intended workload.
+   
+2. [**Post-Registration**](./API-post-registration.md)
+   These api endpoints are used for all activity taking place for a user that has logged in through cognito and acquired a JWT (JSON web token). Authentication is implemented through the signed portion of the JWT, and further authorization can be implemented by the backing lambda functions when they unpack the claims found when inspecting the JWT found in the request cookie header.
+   Post registration api endpoints further subdivide into 4 categories, each designated by the role of the currently authenticated user:
+   - System administrator *(SYS_ADMIN)*
+   - Registered entity administrator *(RE_ADMIN)*
+   - Registered entity authorized individual *(AUTH_IND)*
+   - Consenting Individual *(CONSENTING_INDIVIDUAL)*
+   
+   [REST Api](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html) is chosen over [Http Api](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html) for its [support of integration with a web application firewall *(WAF)*](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html).
+   
+   REST Apis do not have direct support for JWT authorizers as do Http Apis, but you can [control access to a REST API using Amazon Cognito user pools as authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html), which can be based on JWTs *([SEE: Using tokens with User Pools](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html))*.
+   
+   The ETT application uses cognito to implement token based authentication for the internet as detailed in the following blog:  [OAUTH 2 with PKCE in single page apps](https://www.valentinog.com/blog/oauth2/)
+

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -209,15 +209,16 @@
       }
 
       .divSysAdminOption {
-        width: 400px;
+        width: 450px;
         text-align: right;
+        vertical-align: middle;
         padding: 10px;
       }
 
       h3 {
         text-align: center;
         margin-bottom: 20px;
-        margin-top: 20px
+        margin-top: 20px  
       }
 
       #stage {
@@ -608,9 +609,6 @@
                 <li class="nav-item">
                   <a class="nav-link active" id="re-admin-entity-link" data-toggle="tab" href="#re-admin-entity" role="tab" aria-controls="re-admin-entity" aria-selected="true">Entity/Organization</a>
                 </li>
-                <li class="nav-item" id="re-admin-invitation-tab">
-                  <a class="nav-link" id="re-admin-invitation-link" data-toggle="tab" href="#re-admin-invitation" role="tab" aria-controls="re-admin-invitation" aria-selected="false">Invitation</a>
-                </li>
                 <li class="nav-item">
                   <a class="nav-link" id="re-admin-misc-link" data-toggle="tab" href="#re-admin-misc" role="tab" aria-controls="re-admin-misc" aria-selected="false">Miscellaneous</a>
                 </li>
@@ -619,35 +617,27 @@
               <div class="tab-content" id="reAdminContent">
                 <div class="tab-pane fade show active" id="re-admin-entity" role="tabpanel" aria-labelledby="re-admin-entity-link">
                   <div id="divCreateEntity">
-                    <h3 class="display-7 fw-bold">Create your entity</h3>
+                    <h3 class="display-7 fw-bold">Create your entity and invite authorized individuals</h3>
                     <div id="divReAdminEntityName" class="divSysAdminOption" style="text-align: right;">
                       Entity Name:
                       <input id="txtReAdminEntityName" type="text" class="form-control" style="width:fit-content; display:inline-block;">
+                      <button id="btnReAdminEntityUpdate" class="btn btn-primary" type="button">Update</button>
+                    </div>
+                    <div id="divReAdminEmailToInvite" class="divSysAdminOption" style="text-align: right;">
+                      <div style="padding: 20px;">
+                        Authorized Individual Invitee Email Addresses
+                      </div>                
+                      Email 1:
+                      <input id="txtReAdminEmailToInvite1" type="text" class="form-control" style="width:fit-content; display:inline-block;">
                     </div>                
-                    <div id="divReAdminEntityDesc" class="divSysAdminOption" style="text-align: right;">
-                      Entity Description:
-                      <input id="txtReAdminEntityDesc" type="text" class="form-control" style="width:fit-content; display:inline-block;">
+                    <div id="divReAdminEmailToInvite" class="divSysAdminOption" style="text-align: right;">
+                      Email 2:
+                      <input id="txtReAdminEmailToInvite2" type="text" class="form-control" style="width:fit-content; display:inline-block;">
                     </div>                
                     <div class="divSysAdminOption">
-                      <button id="btnReAdminEntityCreate" class="btn btn-primary btn-lg" type="button">Create</button>
-                      &nbsp;
-                      <button id="btnReAdminEntityUpdate" class="btn btn-primary btn-lg" type="button" disabled>Update</button>
+                      <button id="btnReAdminInvite" class="btn btn-primary btn-lg" type="button">Create and Invite</button>
                     </div> 
                   </div>                  
-                </div>
-                <div class="tab-pane fade" id="re-admin-invitation" role="tabpanel" aria-labelledby="re-admin-invitation-link">
-                  <div id="divReAdminInvite">
-                    <h3 class="display-7 fw-bold">Invite an authorized Individual to <span id="re-admin-entity-name">your entity</span></h3>
-                    <div style="display:inline-block; margin-top:30px;">
-                      <div id="divReAdminEmailToInvite" class="divSysAdminOption" style="text-align: right;">
-                        Email Address:
-                        <input id="txtReAdminEmailToInvite" type="text" class="form-control" style="width:fit-content; display:inline-block;">
-                      </div>                
-                      <div class="divSysAdminOption">
-                        <button id="btnReAdminInvite" class="btn btn-primary btn-lg" type="button">Invite</button>
-                      </div> 
-                    </div>
-                  </div>                   
                 </div>
                 <div class="tab-pane fade" id="re-admin-misc" role="tabpanel" aria-labelledby="re-admin-misc-link">
                   <h3 class="display-7 fw-bold" style="text-align:center; margin-bottom: 20px;">Something else can go here, not sure what</h3>
@@ -1239,6 +1229,7 @@
       try {
         const uri = `${STATIC_PARAMETERS.CONSENT_API_URI}/terminate/${invitationCode}`;
         
+        document.body.style.cursor = 'progress';
         const response = await fetch(uri, {
           method: 'GET',
           credentials: 'omit',
@@ -1246,6 +1237,7 @@
         });
 
         const package = await response.json();
+        document.body.style.cursor = 'progress';
         const { message, payload } = package;
         if(payload.ok) {
           alert('Entity terminated');
@@ -1424,18 +1416,14 @@
         const role = AccessJwtCookie.getRole().name;
         const apiUri = STATIC_PARAMETERS.ROLES[role].API_URI
         const entity_name = $('#txtReAdminEntityName').val();
-        const description = $('#txtReAdminEntityDesc').val();
+        const entity_description = entity_name;
         if( ! entity_name) {
           alert('Required entry: Entity name');
           return;
         }
-        if( ! description) {
-          alert('Required entry: Entity description');
-          return;
-        }
         const outgoingPayload = {
           task: 'create-entity',
-          parameters: { entity_name, description }
+          parameters: { entity_name, entity_description }
         }
 
         const response = await fetch(apiUri, {
@@ -1453,9 +1441,7 @@
         const { message, payload } = package;
         if(payload.ok) {
           await setUserContext();
-          $('#btnReAdminEntityCreate').prop("disabled", true);
-          $('#btnReAdminEntityUpdate').prop("disabled", false);
-          document.getElementById('re-admin-invitation-tab').style.display = 'inline';
+          document.getElementById('btnReAdminEntityUpdate').style.display = 'inline';
           alert('Entity created');
         }
         else {
@@ -1467,6 +1453,77 @@
       }
     }
 
+    /**
+     * Combines createEntity and invite (twice) as a consolidated RE_ADMIN task
+     */
+    const createEntityAndInviteUsers = async () => {
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      try {
+        const email = IDJwtCookie.getUser().email;
+        const role = AccessJwtCookie.getRole().name;
+        const apiUri = STATIC_PARAMETERS.ROLES[role].API_URI
+        const entity_name = $('#txtReAdminEntityName').val();
+        const email1 = $('#txtReAdminEmailToInvite1').val();
+        const email2 = $('#txtReAdminEmailToInvite2').val();
+        const description = entity_name;
+        if( ! entity_name) {
+          alert('Required entry: Entity name');
+          return;
+        } 
+        if( ! email1) {
+          alert('Required entry: Authorized Individual 1 email address');
+          return;
+        }
+        if( ! email2) {
+          alert('Required entry: Authorized Individual 2 email address');
+          return;
+        }
+        const outgoingPayload = {
+          task: 'create-entity-invite',
+          // parameters: { email, role, entity_name, description, email1, email2 }
+          parameters: {
+            entity: {
+              name:entity_name, description:entity_name
+            },
+            invitations: {
+              from: {
+                email, role
+              },
+              invitee1: { email: email1, role:'RE_AUTH_IND' },
+              invitee2: { email: email2, role:'RE_AUTH_IND' }
+            }
+          }
+        }
+
+        document.body.style.cursor = 'progress';
+        const response = await fetch(apiUri, {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify(outgoingPayload)
+          }
+        });
+
+        const package = await response.json();
+        document.body.style.cursor = 'default';
+        const { message, payload } = package;
+        if(payload.ok) {
+          userContext = payload.user;
+          document.getElementById('btnReAdminEntityUpdate').style.display = 'inline';
+          alert('Entity created');
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
+    }
 
     /**
      * This function serves as a utility object for processing JWTs received from cognito and the cookies they are stored in.
@@ -1593,13 +1650,20 @@
     // Check the querystring for action=login on page load
 
     $( document ).ready(function() {
-      onDocumentLoad().then(() => console.log('onDocumentLoad complete.'));
+      onDocumentLoad()
+      .then(() => {
+        console.log('onDocumentLoad complete.')
+      })
+      .finally(() => {
+        document.body.style.display = 'default';
+      });
     });
     // window.onload = () => {
     //   onDocumentLoad().then(() => console.log('onDocumentLoad complete.'));;
     // }
 
     const onDocumentLoad = async () => {
+      document.body.style.display = 'progress';
       const queryParams = new URLSearchParams(window.location.search);
 
       // Get querystring parameters
@@ -1634,10 +1698,8 @@
         const apiUri = STATIC_PARAMETERS.ROLES['SYS_ADMIN'].API_URI;
         invite(role, email, apiUri);
       });
-      document.getElementById('btnReAdminInvite').addEventListener('click', () => {
-        const email = $('#txtReAdminEmailToInvite').val();
-        const apiUri = STATIC_PARAMETERS.ROLES['RE_ADMIN'].API_URI;
-        invite('RE_AUTH_IND', email, apiUri);
+      document.getElementById('btnReAdminInvite').addEventListener('click', async () => {
+        await createEntityAndInviteUsers();
       });
       document.getElementsByName('rdoSysAdminInvite').forEach(rdo => {
         rdo.addEventListener('click', () => {
@@ -1650,9 +1712,6 @@
           email.style.display = 'inline-block';
           if( val == 'RE_AUTH_IND') entities.style.display = 'inline-block';
         })
-      });
-      document.getElementById('btnReAdminEntityCreate').addEventListener('click', async () => {
-        await createEntity();
       });
 
       // Add show/hide behavior to the SYS_ADMIN tabstrip
@@ -1682,11 +1741,10 @@
               await setUserContext();
               const entity = userContext?.entity || {};
               const isEmpty = e => Object.keys(e).length == 0;
-              document.getElementById('re-admin-invitation-tab').style.display = isEmpty(entity) ? 'none' : 'inline';
-              $('#btnReAdminEntityCreate').prop("disabled", !isEmpty(entity));
-              $('#btnReAdminEntityUpdate').prop("disabled", isEmpty(entity));
+              if(isEmpty(entity)) {
+                $('#btnReAdminEntityUpdate').hide();
+              }
               $('#txtReAdminEntityName').val(entity.entity_name);
-              $('#txtReAdminEntityDesc').val(entity.description);
               document.getElementById('app-section-RE_ADMIN').style.display = 'inline';
               break;
 

--- a/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
+++ b/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
@@ -78,7 +78,6 @@ export const demolishEntity = async (entity_id:string, notify:boolean, dryRun?:b
   
   // For every user deleted by the demolish operation, notify them it happened by email.
   if(notify) {
-    const fromEmail = await getSysAdminEmail();
     const isEmail = (email:string|undefined) => /@/.test(email||'');
     const emailAddresses:string[] = entityToDemolish.deletedUsers
       .map((user:User) => { return isEmail(user.email) ? user.email : ''; })

--- a/lib/lambda/functions/sys-admin/SysAdminUser.ts
+++ b/lib/lambda/functions/sys-admin/SysAdminUser.ts
@@ -2,7 +2,7 @@ import { AbstractRoleApi, IncomingPayload, LambdaProxyIntegrationResponse } from
 import { Role, Roles } from '../../_lib/dao/entity';
 import { SignupLink } from '../../_lib/invitation/SignupLink';
 import { debugLog, errorResponse, invalidResponse, log, lookupCloudfrontDomain, okResponse } from "../Utils";
-import { Task as ReAdminTasks, lookupEntity, createEntity, deactivateEntity, inviteUser, updateEntity } from '../re-admin/ReAdminUser';
+import { Task as ReAdminTasks, lookupEntity, createEntity, deactivateEntity, inviteUser, updateEntity, createEntityAndInviteUsers } from '../re-admin/ReAdminUser';
 
 export enum Task {
   REPLACE_RE_ADMIN = 'replace_re_admin'
@@ -55,6 +55,8 @@ export const handler = async (event:any):Promise<LambdaProxyIntegrationResponse>
             }
             return await new SignupLink().getRegistrationLink(entity_id);
           });
+        case ReAdminTasks.CREATE_ENTITY_INVITE:
+          return await createEntityAndInviteUsers(parameters);
         case ReAdminTasks.PING:
           return okResponse('Ping!', parameters);
         case Task.REPLACE_RE_ADMIN:


### PR DESCRIPTION
Integrating the following actions an RE_ADMIN can take into a single "one shot" api call.
This will supplant formerly making 3 separate api calls to accomplish the same thing.

1. Create entity
2. Invite authorized individual 1
3. Invite authorized individual 2