### PR TITLE
Sysadmin addons

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -377,6 +377,33 @@
         "RUN_MANUALLY_TEXTLINE"
       ],
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Html Table View",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/functions/sys-admin/view/HtmlTableView.ts",
+        "RUN_MANUALLY_TABLE_VIEW"
+      ],
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Dynamodb Table View",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/functions/sys-admin/DynamoDbTableOutput.ts",
+        "RUN_MANUALLY_DYNAMODB_DISPLAY",
+        "cp"
+      ],
+      "env": {
+        "AWS_PROFILE": "bu",
+        "REGION": "us-east-2"
+      },
+    },
 
     // JEST TESTS
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,21 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Config",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/_lib/config/Config.ts",
+        "RUN_MANUALLY_CONFIG"
+      ], 
+      "env": {
+        "AWS_PROFILE": "bu",
+        "REGION": "us-east-2"
+      }, 
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "DAO consenter",
       "skipFiles": [ "<node_internals>/**" ],
       "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ Build the entire application and AWS infrastructure from scratch.
      "ACCOUNT": "[Your account ID]",
      "REGION": "[Your desired region]",
      "BUCKET_NAME": "ett-static-site-content",
+     "CONFIG": {
+       "useDatabase": true,
+       "configs": [
+         { 
+           "name": "auth-ind-nbr", 
+           "value": "2",
+           "config_type": "number",
+           "description": "Number of authorized individuals per entity"
+         },
+         more configurations...
+       ]
+     },
      "TAGS": {
        "Service": "client",
        "Function": "ett",
@@ -36,26 +48,40 @@ Build the entire application and AWS infrastructure from scratch.
      }
    }
    ```
-
+   
    *NOTE: Make sure the BUCKET_NAME value does not collide with an existing bucket.*
-
-2. Obtain [security credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html?icmpid=docs_homepage_genref) for the admin-level [IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) you will be using for accessing the aws account to lookup and/or deploy resources.
+   The "CONFIG" entry is a collection of settings the app will use for reference when carrying out certain business rules. These are mostly duration or timeout thresholds. There is a "useDatabase" setting provided
+   
+   - "true": These configuration values will be loaded into a database table and the lambda functions that drive the app logic will obtain them from there. Also, the sysadmin user will be provided a tab that can be used to modify these values *(useful for testing - no stack update necessary)*.
+   - "false": These configuration values are "hard-coded" into the lambda functions as a single json environment variable.
+      Modification of any of the configurations would require one modifies the context.json file and perform a stack update.
+   
+   The full configuration listing is as follows:
+   
+   - **auth-ind-nbr:** Number of authorized individuals per entity
+   - **first-reminder:** Duration between an initial disclosure request and the 1st automated reminder (seconds)
+   - **second-reminder:** Duration between an initial disclosure request and the second automated reminder (seconds)
+   - **delete-exhibit-forms-after:** Duration exhibit forms, once submitted, can survive in the ETT system before failure to send disclosure request(s) will result their deletion (seconds)
+   - **delete-drafts-after:** Duration that partially complete exhibit forms can survive in the ETT system before failure to submit them will result in their deletion (seconds)
+   - **consent-expiration:** Duration an individuals consent is valid for before it automatically expires (seconds)
+   
+3. Obtain [security credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html?icmpid=docs_homepage_genref) for the admin-level [IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) you will be using for accessing the aws account to lookup and/or deploy resources.
    Create a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-using-profiles) out of these credentials in your [`~/.aws/credentials`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where) file.
 
-3. Install all dependencies:
+4. Install all dependencies:
 
    ```
    for line in $(find . -maxdepth 4 -name package.json -print | grep -v '/node_modules/') ; do (cd $(dirname $line) && npm install); done \;
    ```
 
-4. *Bootstrapping* is the process of provisioning resources for the AWS CDK before you can deploy AWS CDK apps into an AWS [environment](https://docs.aws.amazon.com/cdk/v2/guide/environments.html). *(An AWS environment is a combination of an AWS account and Region).* You only need to bootstrap once for your chosen region within your account. The presence of a `"CDKToolKit"` cloud-formation stack for that region will indicate bootstrapping has already occurred. To bootstrap, follow [these steps](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html#bootstrapping-howto). The simple bootstrapping command is:
+5. *Bootstrapping* is the process of provisioning resources for the AWS CDK before you can deploy AWS CDK apps into an AWS [environment](https://docs.aws.amazon.com/cdk/v2/guide/environments.html). *(An AWS environment is a combination of an AWS account and Region).* You only need to bootstrap once for your chosen region within your account. The presence of a `"CDKToolKit"` cloud-formation stack for that region will indicate bootstrapping has already occurred. To bootstrap, follow [these steps](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html#bootstrapping-howto). The simple bootstrapping command is:
 
    ```
    export AWS_PROFILE=my_named_profile
    cdk bootstrap aws://[aws account ID]/us-east-1
    ```
 
-5. [OPTIONAL] Run the [CDK synth command](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-synth) command to generate the cloudformation template that will be used to create the stack:
+6. [OPTIONAL] Run the [CDK synth command](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-synth) command to generate the cloudformation template that will be used to create the stack:
 
    ```
    mkdir ./cdk.out 2> /dev/null
@@ -64,7 +90,7 @@ Build the entire application and AWS infrastructure from scratch.
 
    *NOTE: The synth command will create a .json file, but will also output yaml to stdout. The command above redirects that output to a yaml file alongside the json file.*
 
-6. [OPTIONAL] Debug synthesis with breakpoints:
+7. [OPTIONAL] Debug synthesis with breakpoints:
    If developing in vscode, add the following debug configuration to the `${workspaceFolder}/.vscode/launch.json` file:
 
    ```
@@ -85,19 +111,19 @@ Build the entire application and AWS infrastructure from scratch.
 
    Place a breakpoint at the desired location and run the launch configuration.
 
-6. Enable API Gateway Logging for the account. Follow [these directions](./docs/EnableApiGatewayLogging.md)
-  
-6. Run the [CDK deploy command](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-deploy) to create the stack:
+8. Enable API Gateway Logging for the account. Follow [these directions](./docs/EnableApiGatewayLogging.md)
+
+9. Run the [CDK deploy command](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-deploy) to create the stack:
 
    ```
    npm run deploy
    ```
-   
+
    or to completely tear down and replace a stack without prompts use:
-   
+
    ```
    npm run redeploy
    ```
-   
+
    
 

--- a/contexts/IContext.ts
+++ b/contexts/IContext.ts
@@ -1,17 +1,25 @@
+import { Config, ConfigNames } from "../lib/lambda/_lib/dao/entity";
+
 export interface IContext {
   SCENARIO: SCENARIO;
   STACK_ID: string;
   ACCOUNT:  string;
   REGION:   string;
   BUCKET_NAME: string;
-  CLOUDFRONT_DOMAIN: string;
-  CLOUDFRONT_CERTIFICATE: string;
+  CLOUDFRONT_DOMAIN?: string;
+  CLOUDFRONT_CERTIFICATE?: string;
+  CONFIG: CONFIG;
   TAGS:     Tags;
 }
 
 export enum SCENARIO {
   DEFAULT = 'default',
   DYNAMODB = 'dynamodb',
+}
+
+export interface CONFIG {
+  configs: Config[],
+  useDatabase: boolean;
 }
 
 export interface Tags {

--- a/contexts/context.json
+++ b/contexts/context.json
@@ -4,6 +4,47 @@
   "ACCOUNT": "037860335094",
   "REGION": "us-east-2",
   "BUCKET_NAME": "ett-static-site-content",
+  "CONFIG": {
+    "useDatabase": true,
+    "configs": [
+      { 
+        "name": "auth-ind-nbr", 
+        "value": "2",
+        "config_type": "number",
+        "description": "Number of authorized individuals per entity"
+      },
+      { 
+        "name": "first-reminder", 
+        "value": "1209600",
+        "config_type": "duration",
+        "description": "Duration between an initial disclosure request and the 1st automated reminder"
+      },
+      { 
+        "name": "second-reminder", 
+        "value": "1814400",
+        "config_type": "duration",
+        "description": "Duration between an initial disclosure request and the second automated reminder"
+      },
+      { 
+        "name": "delete-exhibit-forms-after", 
+        "value": "5184000",
+        "config_type": "duration",
+        "description": "Duration exhibit forms, once submitted, can survive in the ETT system before failure to send disclosure request(s) will result their deletion"
+      },
+      { 
+        "name": "delete-drafts-after", 
+        "value": "172800",
+        "config_type": "duration",
+        "description": "Duration that partially complete exhibit forms can survive in the ETT system before failure to submit them will result in their deletion"
+      },
+      { 
+        "name": "consent-expiration", 
+        "value": "315360000",
+        "config_type": "duration",
+        "description": "Duration an individuals consent is valid for before it automatically expires"
+      }
+    ]
+  },
   "TAGS": {
     "Service": "client",
     "Function": "ett",

--- a/frontend/bootstrap-duration-picker.css
+++ b/frontend/bootstrap-duration-picker.css
@@ -1,0 +1,12 @@
+.bdp-input input {
+    display: inline-block;
+    margin-bottom: 3px;
+    width: 60px;
+}
+
+.bdp-block {
+    display: inline-block;
+    line-height: 1;
+    text-align: center;
+    padding: 5px 3px;
+}

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -311,6 +311,12 @@
         text-align:right;
       }
       /* div.bdp-input {
+        overflow: auto;
+      } */
+      div.bdp-block input, div.bdp-block div {
+        width:70px;
+        display:inline-table;      
+      }
 
       /* .text-left {
         text-align: left;
@@ -764,6 +770,9 @@
                   <a class="nav-link active" id="sys-admin-invitation-tab" data-toggle="tab" href="#sys-admin-invitation" role="tab" aria-controls="sys-admin-invitation" aria-selected="false">Invitation</a>
                 </li>
                 <li class="nav-item">
+                  <a class="nav-link" id="sys-admin-config-tab" data-toggle="tab" href="#sys-admin-config" role="tab" aria-controls="sys-admin-config" aria-selected="false">Configuration</a>
+                </li>
+                <li class="nav-item">
                   <a class="nav-link" id="sys-admin-db-tab" data-toggle="tab" href="#sys-admin-db" role="tab" aria-controls="sys-admin-db" aria-selected="false">Database</a>
                 </li>
               </ul>
@@ -800,6 +809,63 @@
                       <button id="btnSysAdminInvite" class="btn btn-primary btn-lg" type="button">Invite</button>
                     </div>
                   </div>
+                </div>
+                <div class="tab-pane fade" id="sys-admin-config" role="tabpanel" aria-labelledby="sys-admin-config-tab">
+                  <h3 class="display-7 fw-bold" style="text-align:center; margin-bottom: 20px;">ETT configuration</h3>
+                  <table class="sysAdminConfig" style="border-style:none; padding:5px;">
+                    <tr>
+                      <th>Description</th>
+                      <th>Default Value</th>
+                      <th style="min-width: 180px;">Current Value</th>
+                      <th>&nbsp;</th>
+                    </tr>
+                    <tr>
+                      <td>Number of authorized individuals per entity</td>
+                      <td>2</td>
+                      <td>
+                        <select id="lbxSysAdminConfigAuthIndNbr" class="form-control" style="width:fit-content; display:inline-block;">
+                          <script>for(var i=2; i<=10; i++) { document.writeln(`<option value='${i}'>${i}</option>`); }</script>
+                        </select>
+                      </td>
+                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('auth-ind-nbr');">Update</button></td>
+                    </tr>
+                    <tr>
+                      <td>Duration between an initial disclosure request and the 1st automated reminder<br><span style="font-style: italic;">(set to "0" to negate the reminder)</span></td>
+                      <td>2 weeks</td>
+                      <td><input type="text" id="1st-reminder"></td>
+                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('1st-reminder');">Update</button></td>
+                    </tr>
+                    <tr>
+                      <td>Duration between an initial disclosure request and the 2nd automated reminder<br><span style="font-style: italic;">(set to "0" to negate the reminder)</span></td>
+                      <td>1 week</td>
+                      <td><input type="text" class="form-control" id="2nd-reminder"></td>
+                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('2nd-reminder');">Update</button></td>
+                    </tr>
+                    <tr>
+                      <td>Duration between an initial disclosure request and the 3rd automated reminder<br><span style="font-style: italic;">(set to "0" to negate the reminder)</span>.</td>
+                      <td>0</td>
+                      <td><input type="text" class="form-control" id="3rd-reminder"></td>
+                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('3rd-reminder');">Update</button></td>
+                    </tr>
+                    <tr>
+                      <td>Duration between an initial disclosure request and the 4th automated reminder<br><span style="font-style: italic;">(set to "0" to negate the reminder)</span></td>
+                      <td>0</td>
+                      <td><input type="text" class="form-control" id="4th-reminder"></td>
+                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('4th-reminder');">Update</button></td>
+                    </tr>
+                    <tr>
+                      <td>Duration exhibit forms, once submitted, can survive in the ETT system before failure to send disclosure request(s) will result their deletion</i></td>
+                      <td>60 days</td>
+                      <td><input type="text" class="form-control" id="delete-exhibit-forms-after"></td>
+                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('delete-exhibit-forms-after');">Update</button></td>
+                    </tr>
+                    <tr>
+                      <td>Duration that partially complete exhibit forms can survive in the ETT system before failure to submit them will result in their deletion</td>
+                      <td>48 hours</td>
+                      <td><input type="text" class="form-control" id="delete-drafts-after"></td>
+                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('delete-drafts-after');">Update</button></td>
+                    </tr>
+                  </table>"
                 </div>
                 <div class="tab-pane fade" id="sys-admin-db" role="tabpanel" aria-labelledby="sys-admin-db-tab">
                   <h3 class="display-7 fw-bold" style="text-align:center; margin-bottom: 20px;">ETT database viewer</h3>
@@ -2224,6 +2290,10 @@
       console.log('not implemented yet');
     }
 
+    const changeConfig = async (config) => {
+      alert(`${config}: NOT IMPLEMENTED`);
+    }
+
     const refreshDbTable = async (tableName) => {
       const msg = document.getElementById('apiResponse');
       msg.innerHTML = '';
@@ -2262,6 +2332,53 @@
       }
     }
 
+    /**
+     * Load the duration picker plugin and activate the pickers
+     */
+    const activateDurationPickers = async () => {
+      // Load and duration picker plugin
+      let { origin } = document.location;
+      if(localTesting()) {
+        origin = '../frontend';
+        const response = await fetch('../contexts/context.json', { method: 'GET' });
+        const package = await response.json();
+        const { CONFIG } = package ?? {};
+        const { configs } = CONFIG ?? {};
+      }
+      else {
+        console.log('coming')
+      }
+      const bdpScript = document.createElement('script');
+      bdpScript.src = `${origin}/bootstrap-duration-picker.js`;
+      bdpScript.async = false;
+      const minute = 60;
+      const hour = minute * 60;
+      const day = hour * 24;
+      const week = day * 7;
+      bdpScript.onload = e => {
+        // Activate the duration pickers
+        const tbl = document.getElementById('sysAdminConfig');
+        // TODO: Change this so that they are set by seconds stored in db table and retrieved by api call.
+        const pickers = [
+          { id: '1st-reminder', config: (2 * week) }, 
+          { id: '2nd-reminder', config: week }, 
+          { id: '3rd-reminder', config: 0 }, 
+          { id: '4th-reminder', config: 0 }, 
+          { id: 'delete-exhibit-forms-after', config: (60 * day) }, 
+          { id: 'delete-drafts-after', config: (48 * hour) }, 
+        ];
+        pickers.forEach(item=> {
+          const { id, config } = item;
+          $(`#${id}`).durationPicker({ showSeconds:true });
+          $(`#${id}`).data('durationPicker').setValue(config);
+        })
+      }
+      document.head.appendChild(bdpScript);
+      const bdpLink = document.createElement('link');
+      bdpLink.rel = 'stylesheet';
+      bdpLink.href = `${origin}/frontend/bootstrap-duration-picker.css`;
+      document.head.appendChild(bdpLink);
+    }
 
     /**
      * Signup for a cognito userpool account.
@@ -2766,6 +2883,10 @@
         $(this).tab('show')
       });
 
+      if(selected_role == 'SYS_ADMIN') {
+        await activateDurationPickers();
+      }
+      
       const tooltips = {
         consent: [
           '<b>Ethical Transparency Tool</b> (or ETT) means a tool that enables each Consent Recipient to provide a completed Disclosure Form about a person who has signed and delivered a Consent Form (this form), to any ETT-Registered Entit(ies) that make(s) a request.  Each entity retains its independence in policymaking and decision-making (e.g., when to use the ETT and how to respond to disclosures).',

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -291,6 +291,27 @@
         text-align:left;
       }
 
+      table.sysAdminConfig, table.sysAdminConfig th, table.sysAdminConfig td {
+        border: 1px solid black;
+        border-collapse: collapse;
+      }
+      table.sysAdminConfig th {
+        font-weight: bold;
+        text-align: center;
+        vertical-align: middle;
+      }
+      table.sysAdminConfig td, table.sysAdminConfig th {
+        padding: 15px;
+      }
+      div.dbTableLabel {
+        display:inline-block; 
+        font-size:1.25rem; 
+        font-weight:500; 
+        min-width: 102px; 
+        text-align:right;
+      }
+      /* div.bdp-input {
+
       /* .text-left {
         text-align: left;
       } */
@@ -743,16 +764,15 @@
                   <a class="nav-link active" id="sys-admin-invitation-tab" data-toggle="tab" href="#sys-admin-invitation" role="tab" aria-controls="sys-admin-invitation" aria-selected="false">Invitation</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" id="sys-admin-misc-tab" data-toggle="tab" href="#sys-admin-misc" role="tab" aria-controls="sys-admin-misc" aria-selected="false">Miscellaneous</a>
+                  <a class="nav-link" id="sys-admin-db-tab" data-toggle="tab" href="#sys-admin-db" role="tab" aria-controls="sys-admin-db" aria-selected="false">Database</a>
                 </li>
               </ul>
               <div class="tab-content" id="sysAdminContent">
                 <div class="tab-pane fade show active" id="sys-admin-invitation" role="tabpanel" aria-labelledby="sys-admin-invitation-tab">
                   <h3 class="display-7 fw-bold">Welcome <span id="SYS_ADMIN_username"></span></h3>
-                  <h3 class="display-7 fw-bold">Invite a registered entity administrator</h3>
+                  <h3 class="display-7 fw-bold">Invite a participant</h3>
                   <div style="display:inline-block; width:405px;">
-                    <div style="display:none;">
-                      <!-- Temporarily hiding the radio buttons -->
+                    <div>
                       <div class="divSysAdminOption">
                         Another System Administrator:&nbsp;
                         <input type="radio" name="rdoSysAdminInvite" value="SYS_ADMIN">
@@ -778,11 +798,33 @@
                     </div>                
                     <div class="divSysAdminOption">
                       <button id="btnSysAdminInvite" class="btn btn-primary btn-lg" type="button">Invite</button>
-                    </div> 
+                    </div>
                   </div>
                 </div>
-                <div class="tab-pane fade" id="sys-admin-misc" role="tabpanel" aria-labelledby="sys-admin-misc-tab">
-                  <h3 class="display-7 fw-bold" style="text-align:center; margin-bottom: 20px;">Something else can go here, not sure what</h3>
+                <div class="tab-pane fade" id="sys-admin-db" role="tabpanel" aria-labelledby="sys-admin-db-tab">
+                  <h3 class="display-7 fw-bold" style="text-align:center; margin-bottom: 20px;">ETT database viewer</h3>
+                  <div style="overflow:auto;">
+                    <div style="float:left; clear:both; margin-bottom: 30px;">
+                      <div class="dbTableLabel">Entities</div>
+                      <button class="btn btn-primary btn" type="button" onclick="refreshDbTable('entities')">Load/Refresh</button>
+                      <div id="db-table-entities" style="margin-top:10px;"></div>
+                    </div>
+                    <div style="float:left; clear:both; margin-bottom: 30px;">
+                      <div class="dbTableLabel">Invitations</div>
+                      <button class="btn btn-primary btn" type="button" onclick="refreshDbTable('invitations')">Load/Refresh</button>
+                      <div id="db-table-invitations" style="margin-top:10px;"></div>
+                    </div>
+                    <div style="float:left; clear:both; margin-bottom: 30px;">
+                      <div class="dbTableLabel">Users</div>
+                      <button class="btn btn-primary btn" type="button" onclick="refreshDbTable('users')">Load/Refresh</button>
+                      <div id="db-table-users" style="margin-top:10px;"></div>
+                    </div>
+                    <div style="float:left; clear:both;">
+                      <div class="dbTableLabel">Consenters</div>
+                      <button class="btn btn-primary btn" type="button" onclick="refreshDbTable('consenters')">Load/Refresh</button>
+                      <div id="db-table-consenters" style="margin-top:10px;"></div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -2181,6 +2223,45 @@
     function signSingleExhibitForms() {
       console.log('not implemented yet');
     }
+
+    const refreshDbTable = async (tableName) => {
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      try {
+        const role = AccessJwtCookie.getRole().name;
+        const apiUri = STATIC_PARAMETERS.ROLES[role].API_URI
+        
+        document.body.style.cursor = 'progress';
+        const response = await fetch(apiUri, {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify({
+              task: 'get-db-table',
+              parameters: { tableName }
+            })
+          }
+        });
+
+        const package = await response.json();
+        document.body.style.cursor = 'default';
+        const { message, payload } = package;
+        if(payload.ok) {
+          const { html } = payload;
+          document.getElementById(`db-table-${tableName}`).innerHTML = html;
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
+    }
+
 
     /**
      * Signup for a cognito userpool account.

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -812,58 +812,10 @@
                 </div>
                 <div class="tab-pane fade" id="sys-admin-config" role="tabpanel" aria-labelledby="sys-admin-config-tab">
                   <h3 class="display-7 fw-bold" style="text-align:center; margin-bottom: 20px;">ETT configuration</h3>
-                  <table class="sysAdminConfig" style="border-style:none; padding:5px;">
+                  <table id="tblSysAdminConfig" class="sysAdminConfig" style="border-style:none; padding:5px;">
                     <tr>
                       <th>Description</th>
-                      <th>Default Value</th>
-                      <th style="min-width: 180px;">Current Value</th>
-                      <th>&nbsp;</th>
-                    </tr>
-                    <tr>
-                      <td>Number of authorized individuals per entity</td>
-                      <td>2</td>
-                      <td>
-                        <select id="lbxSysAdminConfigAuthIndNbr" class="form-control" style="width:fit-content; display:inline-block;">
-                          <script>for(var i=2; i<=10; i++) { document.writeln(`<option value='${i}'>${i}</option>`); }</script>
-                        </select>
-                      </td>
-                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('auth-ind-nbr');">Update</button></td>
-                    </tr>
-                    <tr>
-                      <td>Duration between an initial disclosure request and the 1st automated reminder<br><span style="font-style: italic;">(set to "0" to negate the reminder)</span></td>
-                      <td>2 weeks</td>
-                      <td><input type="text" id="1st-reminder"></td>
-                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('1st-reminder');">Update</button></td>
-                    </tr>
-                    <tr>
-                      <td>Duration between an initial disclosure request and the 2nd automated reminder<br><span style="font-style: italic;">(set to "0" to negate the reminder)</span></td>
-                      <td>1 week</td>
-                      <td><input type="text" class="form-control" id="2nd-reminder"></td>
-                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('2nd-reminder');">Update</button></td>
-                    </tr>
-                    <tr>
-                      <td>Duration between an initial disclosure request and the 3rd automated reminder<br><span style="font-style: italic;">(set to "0" to negate the reminder)</span>.</td>
-                      <td>0</td>
-                      <td><input type="text" class="form-control" id="3rd-reminder"></td>
-                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('3rd-reminder');">Update</button></td>
-                    </tr>
-                    <tr>
-                      <td>Duration between an initial disclosure request and the 4th automated reminder<br><span style="font-style: italic;">(set to "0" to negate the reminder)</span></td>
-                      <td>0</td>
-                      <td><input type="text" class="form-control" id="4th-reminder"></td>
-                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('4th-reminder');">Update</button></td>
-                    </tr>
-                    <tr>
-                      <td>Duration exhibit forms, once submitted, can survive in the ETT system before failure to send disclosure request(s) will result their deletion</i></td>
-                      <td>60 days</td>
-                      <td><input type="text" class="form-control" id="delete-exhibit-forms-after"></td>
-                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('delete-exhibit-forms-after');">Update</button></td>
-                    </tr>
-                    <tr>
-                      <td>Duration that partially complete exhibit forms can survive in the ETT system before failure to submit them will result in their deletion</td>
-                      <td>48 hours</td>
-                      <td><input type="text" class="form-control" id="delete-drafts-after"></td>
-                      <td><button class="btn btn-primary btn" type="button" onclick="changeConfig('delete-drafts-after');">Update</button></td>
+                      <th style="min-width: 180px;" colspan="2">Current Value</th>
                     </tr>
                   </table>"
                 </div>
@@ -2290,10 +2242,6 @@
       console.log('not implemented yet');
     }
 
-    const changeConfig = async (config) => {
-      alert(`${config}: NOT IMPLEMENTED`);
-    }
-
     const refreshDbTable = async (tableName) => {
       const msg = document.getElementById('apiResponse');
       msg.innerHTML = '';
@@ -2333,20 +2281,71 @@
     }
 
     /**
+     * Obtain the output of a fetch to the configuration api endpoint
+     */
+    const getAppConfigs = async () => {
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      try {
+        const role = AccessJwtCookie.getRole().name;
+        const apiUri = STATIC_PARAMETERS.ROLES[role].API_URI
+        
+        document.body.style.cursor = 'progress';
+        const response = await fetch(apiUri, {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify({
+              task: 'get-app-configs',
+              parameters: { }
+            })
+          }
+        });
+
+        const package = await response.json();
+        document.body.style.cursor = 'default';
+        const { message, payload } = package;
+        if(payload.ok) {
+          const { configs } = payload;
+          return configs;
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
+    }
+
+    /**
      * Load the duration picker plugin and activate the pickers
      */
-    const activateDurationPickers = async () => {
+    const buildConfigurationsTable = async () => {
       // Load and duration picker plugin
       let { origin } = document.location;
+      let configs;
       if(localTesting()) {
         origin = '../frontend';
-        const response = await fetch('../contexts/context.json', { method: 'GET' });
-        const package = await response.json();
-        const { CONFIG } = package ?? {};
-        const { configs } = CONFIG ?? {};
+        // Load the table with static dummy data.
+        configs = [
+          { name:'consent-expiration', value:'315360000', config_type: 'duration' },
+          { name:'auth-ind-nbr', value:'2', config_type: 'number' },
+          { name:'first-reminder', value:'1209600', config_type: 'duration' },
+          { name:'second-reminder', value:'1814400', config_type: 'duration' },
+          { name:'third-reminder', value:'0', config_type: 'duration' },
+          { name:'fourth-reminder', value:'0', config_type: 'duration' },
+          { name:'delete-exhibit-forms-after', value:'5184000', config_type: 'duration' },
+          { name:'delete-drafts-after', value:'172800', config_type: 'duration' },
+        ]
+        configs = configs.map(c => { return Object.assign(c, { description: `${c.name} description` }); })
       }
       else {
-        console.log('coming')
+        // Load the table with the output of a fetch to the configuration api endpoint
+        configs = await getAppConfigs();
       }
       const bdpScript = document.createElement('script');
       bdpScript.src = `${origin}/bootstrap-duration-picker.js`;
@@ -2355,29 +2354,98 @@
       const hour = minute * 60;
       const day = hour * 24;
       const week = day * 7;
+      
+      // Load the config table with rows, one row for each configuration.
       bdpScript.onload = e => {
-        // Activate the duration pickers
-        const tbl = document.getElementById('sysAdminConfig');
-        // TODO: Change this so that they are set by seconds stored in db table and retrieved by api call.
-        const pickers = [
-          { id: '1st-reminder', config: (2 * week) }, 
-          { id: '2nd-reminder', config: week }, 
-          { id: '3rd-reminder', config: 0 }, 
-          { id: '4th-reminder', config: 0 }, 
-          { id: 'delete-exhibit-forms-after', config: (60 * day) }, 
-          { id: 'delete-drafts-after', config: (48 * hour) }, 
-        ];
-        pickers.forEach(item=> {
-          const { id, config } = item;
-          $(`#${id}`).durationPicker({ showSeconds:true });
-          $(`#${id}`).data('durationPicker').setValue(config);
+        const tbl = document.getElementById('tblSysAdminConfig');
+        configs.forEach(config => {
+          let tr = tbl.insertRow(-1);
+          // First cell
+          let td = tr.insertCell(-1);
+          let txt = document.createTextNode(config.description);
+          td.appendChild(txt);
+          // Second cell
+          td = tr.insertCell(-1);
+          let input = document.createElement('input');
+          input.id = config.name;
+          input.className = 'form-control input-sm';
+          input.type = 'text';
+          switch(config.config_type) {
+            case 'duration':
+              td.appendChild(input);
+              // Activate the duration picker
+              $(`#${config.name}`).durationPicker({ showSeconds:true });
+              $(`#${config.name}`).data('durationPicker').setValue(parseInt(config.value));
+              break;
+            case 'number':
+              input.style = 'display:inline-block;width:180px;';
+              input.type = 'number';
+              input.value = parseInt(config.value);
+              td.appendChild(input);
+              break;
+            default:
+              input.style = 'display:inline-block;width:180px;';
+              input.value = config.value;
+              td.appendChild(input);
+              break;
+          }
+          // Third cell
+          td = tr.insertCell(-1);
+          let button = document.createElement('button');
+          txt = document.createTextNode('Update');
+          button.appendChild(txt);
+          button.className = 'btn btn-primary btn';
+          button.addEventListener('click', async() => {
+            changeConfig(config.name);
+          });
+          td.appendChild(button);
         })
       }
       document.head.appendChild(bdpScript);
-      const bdpLink = document.createElement('link');
-      bdpLink.rel = 'stylesheet';
-      bdpLink.href = `${origin}/frontend/bootstrap-duration-picker.css`;
-      document.head.appendChild(bdpLink);
+      // const bdpLink = document.createElement('link');
+      // bdpLink.rel = 'stylesheet';
+      // bdpLink.href = `${origin}/bootstrap-duration-picker.css`;
+      // document.head.appendChild(bdpLink);
+    }
+
+    /**
+     * Modify a single app configuration setting.
+     */
+    const changeConfig = async (name) => {
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      try {
+        const role = AccessJwtCookie.getRole().name;
+        const apiUri = STATIC_PARAMETERS.ROLES[role].API_URI;
+        const { value } = document.getElementById(name);
+        
+        document.body.style.cursor = 'progress';
+        const response = await fetch(apiUri, {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify({
+              task: 'set-app-config',
+              parameters: { name, value }
+            })
+          }
+        });
+        const package = await response.json();
+        document.body.style.cursor = 'default';
+        const { message, payload } = package;
+        if(payload.ok) {
+          alert(`${name} change succesful`);
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }        
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
     }
 
     /**
@@ -2758,9 +2826,11 @@
 
     const onDocumentLoad = async () => {
       document.body.style.display = 'progress';
-      const queryParams = new URLSearchParams(window.location.search);
+
+      selected_role = getSelectedRole();
 
       // Get querystring parameters
+      const queryParams = new URLSearchParams(window.location.search);
       const action = queryParams.get('action');
       const invitationCode = queryParams.get('code');
 
@@ -2769,7 +2839,7 @@
         signIn();
       });
       document.getElementById('btnSignup').addEventListener('click', () => {
-        if(selected_role = 'CONSENTING_PERSON') {
+        if(selected_role == 'CONSENTING_PERSON') {
           showSection('acknowledge-consenter');
         }
         else {
@@ -2884,7 +2954,7 @@
       });
 
       if(selected_role == 'SYS_ADMIN') {
-        await activateDurationPickers();
+        await buildConfigurationsTable();
       }
       
       const tooltips = {

--- a/lib/Api.ts
+++ b/lib/Api.ts
@@ -48,20 +48,25 @@ export class ApiConstruct extends Construct {
     dynamodb.getEntitiesTable().grantReadWriteData(sysAdminApi.getLambdaFunction());
     dynamodb.getInvitationsTable().grantReadWriteData(sysAdminApi.getLambdaFunction());
     dynamodb.getUsersTable().grantReadWriteData(sysAdminApi.getLambdaFunction());
+    dynamodb.getConsentersTable().grantReadWriteData(sysAdminApi.getLambdaFunction());
+    dynamodb.getConfigTable().grantReadWriteData(sysAdminApi.getLambdaFunction());
 
     // Grant the re administrator api permissions to read/write from the users table
     dynamodb.getUsersTable().grantReadWriteData(reAdminApi.getLambdaFunction());
     dynamodb.getInvitationsTable().grantReadWriteData(reAdminApi.getLambdaFunction());
     dynamodb.getEntitiesTable().grantReadWriteData(reAdminApi.getLambdaFunction());
+    dynamodb.getConfigTable().grantReadData(reAdminApi.getLambdaFunction());
 
     // Grant the authorized individual api permissions to read/write from the users table
     dynamodb.getUsersTable().grantReadWriteData(authIndApi.getLambdaFunction());
     dynamodb.getInvitationsTable().grantReadWriteData(authIndApi.getLambdaFunction());
     dynamodb.getEntitiesTable().grantReadWriteData(authIndApi.getLambdaFunction());
+    dynamodb.getConfigTable().grantReadData(authIndApi.getLambdaFunction());
 
     // Grant the consenter api permissions to read/write from the users table
     dynamodb.getConsentersTable().grantReadWriteData(consentingPersonApi.getLambdaFunction());
     dynamodb.getEntitiesTable().grantReadWriteData(consentingPersonApi.getLambdaFunction());
+    dynamodb.getConfigTable().grantReadData(consentingPersonApi.getLambdaFunction());
   }
 
   public get helloWorldApi(): HelloWorldApi {

--- a/lib/Cognito.ts
+++ b/lib/Cognito.ts
@@ -7,6 +7,7 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import path = require('path');
 import { Effect, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { DynamoDbConstruct } from './DynamoDb';
+import { Configurations } from './lambda/_lib/config/Config';
 
 export class CognitoConstruct extends Construct {
 
@@ -44,6 +45,7 @@ export class CognitoConstruct extends Construct {
       DYNAMODB_INVITATION_TABLE_NAME: DynamoDbConstruct.DYNAMODB_INVITATION_TABLE_NAME,
       DYNAMODB_ENTITY_TABLE_NAME: DynamoDbConstruct.DYNAMODB_ENTITY_TABLE_NAME,
       DYNAMODB_CONSENTER_TABLE_NAME: DynamoDbConstruct.DYNAMODB_CONSENTER_TABLE_NAME,
+      [Configurations.ENV_VAR_NAME]: new Configurations(this.context.CONFIG).getJson() 
     };
 
     const preSignupFunction = new AbstractFunction(this, 'PreSignupFunction', {

--- a/lib/DynamoDb.ts
+++ b/lib/DynamoDb.ts
@@ -2,7 +2,7 @@ import { RemovalPolicy } from "aws-cdk-lib";
 import { AttributeType, Billing, TableV2, TableClass, ProjectionType, TablePropsV2 } from "aws-cdk-lib/aws-dynamodb";
 import { Construct } from "constructs";
 import { IContext } from "../contexts/IContext";
-import { EntityFields, UserFields, InvitationFields, ConsenterFields } from "./lambda/_lib/dao/entity";
+import { EntityFields, UserFields, InvitationFields, ConsenterFields, ConfigFields } from "./lambda/_lib/dao/entity";
 
 export class DynamoDbConstruct extends Construct {
   
@@ -10,6 +10,7 @@ export class DynamoDbConstruct extends Construct {
   static DYNAMODB_ENTITY_TABLE_NAME: string = 'ett-entities';
   static DYNAMODB_INVITATION_TABLE_NAME: string = 'ett-invitations';
   static DYNAMODB_CONSENTER_TABLE_NAME: string = 'ett-consenters';
+  static DYAMODB_CONFIG_TABLE_NAME: string = 'ett-config'
 
   static DYNAMODB_USER_ENTITY_INDEX: string = 'EntityIndex';
   static DYNAMODB_INVITATION_ENTITY_INDEX: string = 'EntityIndex';
@@ -22,6 +23,7 @@ export class DynamoDbConstruct extends Construct {
   private entitiesTable: TableV2;
   private invitationsTable: TableV2;
   private consentersTable: TableV2;
+  private configTable: TableV2;
   
   constructor(scope: Construct, constructId: string, props?:any) {
 
@@ -103,6 +105,17 @@ export class DynamoDbConstruct extends Construct {
       removalPolicy: RemovalPolicy.DESTROY,
       pointInTimeRecovery: true,
       deletionProtection: this.context.TAGS.Landscape == 'prod',
+    } as TablePropsV2);
+
+    // Create a table for system configurations
+    this.configTable = new TableV2(this, 'DbConfig', {
+      tableName: DynamoDbConstruct.DYAMODB_CONFIG_TABLE_NAME,
+      partitionKey: { name: ConfigFields.name, type: AttributeType.STRING },
+      billing: Billing.onDemand(),
+      tableClass: TableClass.STANDARD_INFREQUENT_ACCESS,
+      removalPolicy: RemovalPolicy.DESTROY,
+      pointInTimeRecovery: true,
+      deletionProtection: this.context.TAGS.Landscape == 'prod',
     } as TablePropsV2)
   }
 
@@ -120,5 +133,9 @@ export class DynamoDbConstruct extends Construct {
 
   public getConsentersTable(): TableV2 {
     return this.consentersTable;
+  }
+
+  public getConfigTable(): TableV2 {
+    return this.configTable;
   }
 }

--- a/lib/SignupApi.ts
+++ b/lib/SignupApi.ts
@@ -259,6 +259,9 @@ export class SignupApiConstruct extends Construct {
     dynamodb.getEntitiesTable().grantReadWriteData(this.registerEntityLambda);
     dynamodb.getUsersTable().grantReadWriteData(this.registerEntityLambda);
     dynamodb.getConsentersTable().grantReadWriteData(this.registerConsenterLambda);
+    dynamodb.getConfigTable().grantReadData(this.acknowledgeEntityLambda);
+    dynamodb.getConfigTable().grantReadData(this.registerEntityLambda);
+    dynamodb.getConfigTable().grantReadData(this.registerConsenterLambda);
   }
 
   public get entityAcknowledgeApiUri() {

--- a/lib/SignupApi.ts
+++ b/lib/SignupApi.ts
@@ -8,6 +8,7 @@ import { AbstractFunction } from "./AbstractFunction";
 import { DynamoDbConstruct } from "./DynamoDb";
 import { UserPool } from "aws-cdk-lib/aws-cognito";
 import { AbstractRoleApi, Actions } from "./role/AbstractRole";
+import { Configurations } from "./lambda/_lib/config/Config";
 
 export type SignupApiConstructParms = {
   userPool: UserPool,
@@ -72,7 +73,8 @@ export class SignupApiConstruct extends Construct {
       },
       environment: {
         REGION,
-        CLOUDFRONT_DOMAIN: cloudfrontDomain
+        CLOUDFRONT_DOMAIN: cloudfrontDomain,
+        [Configurations.ENV_VAR_NAME]: new Configurations(this.context.CONFIG).getJson()
       }
     });
 
@@ -164,7 +166,8 @@ export class SignupApiConstruct extends Construct {
       environment: {
         REGION,
         CLOUDFRONT_DOMAIN: cloudfrontDomain,
-        USERPOOL_ID: userPoolId
+        USERPOOL_ID: userPoolId,
+        [Configurations.ENV_VAR_NAME]: new Configurations(this.context.CONFIG).getJson()
       }
     });
 
@@ -223,6 +226,7 @@ export class SignupApiConstruct extends Construct {
       environment: {
         REGION,
         CLOUDFRONT_DOMAIN: cloudfrontDomain,
+        [Configurations.ENV_VAR_NAME]: new Configurations(this.context.CONFIG).getJson()
       }
     });
 

--- a/lib/lambda/_lib/config/Config.ts
+++ b/lib/lambda/_lib/config/Config.ts
@@ -73,7 +73,16 @@ export class Configurations {
     let { configs=[], useDatabase=false } = config ?? { configs:[] };
     let appConfigs:IAppConfig[];
     if(useDatabase) {
-      configs = await getDbConfig() as Config[];
+      let dbOutput = await getDbConfig() as Config[];
+      dbOutput = dbOutput ?? [];
+      if(dbOutput.length == 0) {
+        console.log('Pre-populating database configurations...');
+        // Pre-populate the table - this must be the first time it is being accessed after having been cloudformed.
+        await this.setDbConfigs();
+      }
+      else {
+        configs = dbOutput;
+      }
     }
     appConfigs = configs.map((config:Config) => {
       return new AppConfig(config);
@@ -93,6 +102,19 @@ export class Configurations {
     let _config:Config|undefined;
     if(useDatabase) {
       _config = await getDbConfig(name) as Config;
+      if( ! _config) {
+        let dbOutput = await getDbConfig() as Config[];
+        dbOutput = dbOutput ?? [];
+        if(dbOutput.length == 0) {
+          console.log('Pre-populating database configurations...');
+          // Pre-populate the table - this must be the first time it is being accessed after having been cloudformed.
+          await this.setDbConfigs();
+        }
+        else {
+          configs = dbOutput;
+        }
+        _config = configs.find((config:Config) => config.name == name);
+      }
     }
     else {
       _config = configs.find((config:Config) => config.name == name);

--- a/lib/lambda/_lib/config/Config.ts
+++ b/lib/lambda/_lib/config/Config.ts
@@ -1,0 +1,167 @@
+import { CONFIG } from "../../../../contexts/IContext";
+import { DAOConfig, DAOFactory } from "../dao/dao";
+import { ConfigBatch } from "../dao/dao-config";
+import { Config, ConfigName, ConfigNames, ConfigType, ConfigTypes } from "../dao/entity";
+
+export type IAppConfig = Config & {
+  getDuration():number
+}
+
+/**
+ * Decorator for a Config item for transforming config values.
+ */
+export class AppConfig implements IAppConfig {
+  name: ConfigName;
+  value: string;
+  config_type: ConfigType;
+  description: string;
+  update_timestamp?: string | undefined;
+  constructor(config:Config) {
+    this.name = config.name;
+    this.value = config.value;
+    this.config_type = config.config_type;
+    this.description = config.description;
+    this.update_timestamp = config.update_timestamp
+  }
+  getDuration(): number {
+    const { value, config_type } = this;
+    return config_type == ConfigTypes.DURATION ? parseInt(value) : 0;
+  }
+}
+
+/**
+ * This class represents the application configuration. This is mostly comprised of numeric values
+ * that indicate durations or timeouts after which certain events may occur as per business rules. 
+ */
+export class Configurations {
+
+  static ENV_VAR_NAME:string = 'APP_CONFIG';
+  private config?:CONFIG;
+  
+  /**
+   * Ingest the context-based configuration if provided (directly, or through an environment variable)
+   * @param config 
+   * @returns 
+   */
+  constructor(config?:CONFIG) {    
+    if(config) {
+      this.config = config;
+      return;
+    }
+    const json = process.env[Configurations.ENV_VAR_NAME];
+    if(json) {
+      this.config = JSON.parse(json);
+    }
+  }
+
+  /**
+   * Get the entire app config as a json object. Useful for storing as an environment variable.
+   * @returns 
+   */
+  public getJson = () => {
+    const { config } = this;
+    return config ? JSON.stringify(config): '{}';
+  }
+
+  /**
+   * Get the app configuration. This will come as a result of a database lookup if the context specfies
+   * to do this, else it will come directly from the context itself.
+   * @returns 
+   */
+  public getAppConfigs = async ():Promise<IAppConfig[]> => {
+    const { config, getDbConfig } = this ?? {};
+    let { configs=[], useDatabase=false } = config ?? { configs:[] };
+    let appConfigs:IAppConfig[];
+    if(useDatabase) {
+      configs = await getDbConfig() as Config[];
+    }
+    appConfigs = configs.map((config:Config) => {
+      return new AppConfig(config);
+    });
+    return appConfigs;
+  }
+
+  /**
+   * Get a single item from the app configuration. This will come as a result of a database lookup if the context specfies
+   * to do this, else it will come directly from the context itself.
+   * @param name
+   * @returns 
+   */
+  public getAppConfig = async (name:ConfigName):Promise<IAppConfig> => {
+    const { config, getDbConfig } = this ?? {};
+    let { configs=[], useDatabase=false } = config ?? { configs:[] };
+    let _config:Config|undefined;
+    if(useDatabase) {
+      _config = await getDbConfig(name) as Config;
+    }
+    else {
+      _config = configs.find((config:Config) => config.name == name);
+    }
+    return new AppConfig(_config ?? {} as IAppConfig);
+  }
+
+  /**
+   * Transfer the config settings from the context into the config dynamodb table.
+   * If the table already has content, then matching items will be overwritten.
+   */
+  public setDbConfigs = async ():Promise<void> => {
+    const { configs } = this.config ?? {};
+    await ConfigBatch().create(configs ?? []);
+  }
+
+  /**
+   * Modify a single application configuration in the database.
+   * @param config 
+   */
+  public setDbConfig = async (config:Config):Promise<void> => {
+    const dao = DAOFactory.getInstance({ DAOType: "config", Payload: config });
+    await dao.update();
+  }
+
+  /**
+   * Return the entire contents of the config dynamodb table
+   * @returns 
+   */
+  private getDbConfig = async (name?:string):Promise<(Config|null)|Config[]> => {
+    const dao = DAOFactory.getInstance({ DAOType: "config", Payload: { name } as Config}) as DAOConfig;
+    return dao.read();
+  }
+}
+
+/**
+ * RUN MANUALLY: 
+ */
+const { argv:args } = process;
+if(args.length > 2 && args[2] == 'RUN_MANUALLY_CONFIG') {
+  (async () => {
+    const ctx = await import('../../../../contexts/context.json');
+    ctx.CONFIG.useDatabase = false;
+
+    console.log("Test configurations from an object:")
+    let configs = new Configurations(ctx.CONFIG as CONFIG);
+    let appConfigs = await configs.getAppConfigs();
+    console.log(JSON.stringify(appConfigs));
+    let appConfig = await configs.getAppConfig(ConfigNames.CONSENT_EXPIRATION);
+    console.log(JSON.stringify(appConfig));
+
+    console.log("\nTest configurations from an environment variable:")
+    process.env[Configurations.ENV_VAR_NAME] = JSON.stringify(ctx.CONFIG);
+    configs = new Configurations();
+    appConfigs = await configs.getAppConfigs();
+    console.log(JSON.stringify(appConfigs));
+    appConfig = await configs.getAppConfig(ConfigNames.CONSENT_EXPIRATION);
+    console.log(JSON.stringify(appConfig));
+
+    console.log("\nSaving config to database...");
+    await configs.setDbConfigs();
+
+    console.log("\nTest configurations from database lookup:")
+    ctx.CONFIG.useDatabase = true;
+    configs = new Configurations(ctx.CONFIG as CONFIG);
+    appConfigs = await configs.getAppConfigs();
+    console.log(JSON.stringify(appConfigs));
+    appConfig = await configs.getAppConfig(ConfigNames.CONSENT_EXPIRATION);
+    console.log(JSON.stringify(appConfig));
+
+  })();
+}

--- a/lib/lambda/_lib/config/Config.ts
+++ b/lib/lambda/_lib/config/Config.ts
@@ -35,7 +35,7 @@ export class AppConfig implements IAppConfig {
  */
 export class Configurations {
 
-  static ENV_VAR_NAME:string = 'APP_CONFIG';
+  static ENV_VAR_NAME:string = 'APP_CONFIGS';
   private config?:CONFIG;
   
   /**

--- a/lib/lambda/_lib/dao/dao-config.ts
+++ b/lib/lambda/_lib/dao/dao-config.ts
@@ -1,0 +1,240 @@
+import { BatchWriteItemCommand, BatchWriteItemInput, BatchWriteItemOutput, DeleteItemCommand, DeleteItemCommandInput, DeleteItemCommandOutput, DynamoDBClient, GetItemCommand, GetItemCommandInput, GetItemCommandOutput, ScanCommand, ScanInput, UpdateItemCommand, UpdateItemCommandInput, UpdateItemCommandOutput, WriteRequest } from "@aws-sdk/client-dynamodb";
+import { DAOConfig, ReadParms } from "./dao"
+import { Config, ConfigFields } from "./entity"
+import { DynamoDbConstruct } from "../../../DynamoDb";
+import { configUpdate } from "./db-update-builder.config";
+import { convertFromApiObject } from "./db-object-builder";
+import { marshall } from "@aws-sdk/util-dynamodb";
+
+
+export function ConfigCrud(configInfo:Config, _dryRun:boolean=false): DAOConfig {
+
+  const dbclient = new DynamoDBClient({ region: process.env.REGION });
+  const TableName = DynamoDbConstruct.DYAMODB_CONFIG_TABLE_NAME;
+  
+  let { name, description, update_timestamp, value } = configInfo;
+  
+  let command:any;
+
+  /**
+   * @returns An instance of ConfigCrud with the same configuration that is in "dryrun" mode. That is, when any
+   * operation, like read, update, query, etc is called, the command is withheld from being issued to dynamodb
+   * and is returned instead 
+   */
+  const dryRun = () => {
+    return ConfigCrud(configInfo, true);
+  }
+
+  const throwMissingError = (task:string, fld:string) => {
+    throw new Error(`Config ${task} error: Missing ${fld} in ${JSON.stringify(configInfo, null, 2)}`)
+  }
+
+  /**
+   * Create a new config entry.
+   * @returns 
+   */
+  const create = async (): Promise<UpdateItemCommandOutput> => {
+    // Handle missing field validation
+    if( ! name) throwMissingError('create', ConfigFields.name);
+    if( ! value) throwMissingError('create', ConfigFields.value);
+    if( ! description) throwMissingError('create', ConfigFields.description);
+
+    console.log(`Creating config: ${name}`);
+
+    // Make sure update_timestamp has a value.
+    if( ! update_timestamp) {
+      update_timestamp = new Date().toISOString();
+      configInfo.update_timestamp = update_timestamp;
+    }
+
+    const input = configUpdate(TableName, configInfo).buildUpdateItem() as UpdateItemCommandInput;
+    command = new UpdateItemCommand(input);
+    return await sendCommand(command);
+  }
+
+  const read = async (readParms?:ReadParms):Promise<(Config|null)|Config[]> => {
+    if(name) {
+      return await _read(readParms) as Config;
+    }
+    else {
+      return await _scan(readParms) as Config[];
+    }
+  }
+
+  /**
+   * Get a single config record associated with the specified primary key value (name)
+   * @returns 
+   */
+  const _read = async (readParms?:ReadParms):Promise<Config|null> => {
+    // Handle missing field validation
+    if( ! name) throwMissingError('read', ConfigFields.name);
+
+    console.log(`Reading config: ${name}`);
+    const params = {
+      TableName,
+      Key: {
+        [ConfigFields.name]: { S: name }
+      }
+    } as GetItemCommandInput
+    command = new GetItemCommand(params);
+    const retval:GetItemCommandOutput = await sendCommand(command);
+    if( ! retval.Item) {
+      return null;
+    }
+    const { convertDates } = (readParms ?? {});
+    return await loadConfig(retval.Item, convertDates ?? true) as Config;
+  }
+
+  const _scan = async (readParms?:ReadParms):Promise<Config[]> => {
+    console.log(`Scanning config table`);   
+    const command = new ScanCommand({ TableName } as ScanInput);
+    const retval = await sendCommand(command);
+    const configs = [] as Config[];
+    const { convertDates } = (readParms ?? {});
+    for(const item in retval.Items) {
+      configs.push(await loadConfig(retval.Items[item], convertDates ?? true));
+    }
+    return configs as Config[];
+  }
+
+  /**
+   * Update a specific config record associated with the specified primary key (name)
+   */
+  const update = async ():Promise<UpdateItemCommandOutput> => {
+    // Handle field validation
+    if( ! name) {
+      throwMissingError('update', ConfigFields.name);
+    }
+    if( Object.keys(configInfo).length == 1 ) {
+      throw new Error(`Config update error: No fields to update for ${name}`);
+    }
+    console.log(`Updating config: ${name}`);
+    const input = configUpdate(TableName, configInfo).buildUpdateItem() as UpdateItemCommandInput;
+    command = new UpdateItemCommand(input);
+    return await sendCommand(command);
+  }
+
+  /**
+   * Delete a config entry from the dynamodb table.
+   */
+  const Delete = async ():Promise<DeleteItemCommandOutput> => {
+    const input = {
+      TableName,
+      Key: { 
+         [ConfigFields.name]: { S: name, },
+      },
+    } as DeleteItemCommandInput;
+    command = new DeleteItemCommand(input);
+    return await sendCommand(command);
+  }
+  
+  /**
+   * Envelope the clientdb send function with error handling.
+   * @param command 
+   * @returns 
+   */
+  const sendCommand = async (command:any): Promise<any> => {
+    let response;
+    try {
+      if(_dryRun) {
+        response = command;
+      }
+      else {
+        response = await dbclient.send(command);
+      }           
+    }
+    catch(e) {
+      console.error(e);
+    }          
+    return response;
+  }
+
+  const loadConfig = async (entity:any, convertDates:boolean):Promise<Config> => {
+    return new Promise( resolve => {
+      resolve(convertFromApiObject(entity, convertDates) as Config);
+    });
+  }
+
+  const test = async () => {
+    await read();
+  }
+
+  return { create, read, update, Delete, dryRun, test, } as DAOConfig;
+}
+
+
+export type DAOConfigBatch = { create(configs:Config[]):Promise<any>, Delete(names:string[]):Promise<any> }
+
+export function ConfigBatch(_dryRun:boolean=false): DAOConfigBatch {
+
+  const dbclient = new DynamoDBClient({ region: process.env.REGION });
+  const TableName = DynamoDbConstruct.DYAMODB_CONFIG_TABLE_NAME;
+
+  /**
+   * Put multiple items into the table as one operation
+   * @param configs 
+   * @returns 
+   */
+  const create = async (configs:Config[]): Promise<BatchWriteItemOutput> => {
+    const writeRequests = [] as WriteRequest[];
+    configs.forEach((config:Config) => {
+      writeRequests.push({
+        PutRequest: {
+          Item: marshall(config)
+        }
+      } as WriteRequest)
+    });
+
+    const input = {
+      RequestItems: {
+        [TableName]: writeRequests
+      }
+    } as BatchWriteItemInput;
+
+    const command = new BatchWriteItemCommand(input);
+    return sendCommand(command);
+  };
+
+  /**
+   * Delete multiple items from the table as one operation
+   * @param names 
+   * @returns 
+   */
+  const Delete = async (names:string[]):Promise<BatchWriteItemOutput> => {
+    const writeRequests = [] as WriteRequest[];
+    names.forEach((name:string) => {
+      writeRequests.push({
+        DeleteRequest: {
+          Key: marshall({ name })
+        }
+      } as WriteRequest)
+    });
+
+    const input = {
+      RequestItems: {
+        [TableName]: writeRequests
+      }
+    } as BatchWriteItemInput;
+
+    const command = new BatchWriteItemCommand(input);
+    return sendCommand(command);
+  }
+
+  /**
+   * Envelope the clientdb send function with error handling.
+   * @param command 
+   * @returns 
+   */
+  const sendCommand = async (command:any): Promise<any> => {
+    let response;
+    try {
+      response = await dbclient.send(command);           
+    }
+    catch(e) {
+      console.error(e);
+    }          
+    return response;
+  }
+
+  return { create, Delete }
+}

--- a/lib/lambda/_lib/dao/dao.ts
+++ b/lib/lambda/_lib/dao/dao.ts
@@ -1,8 +1,9 @@
+import { ConfigCrud } from './dao-config';
 import { ConsenterCrud } from './dao-consenter';
 import { EntityCrud } from './dao-entity';
 import { InvitationCrud } from './dao-invitation';
 import { UserCrud } from './dao-user';
-import { Consenter, Entity, Invitation, User, Validator } from './entity';
+import { Config, Consenter, Entity, Invitation, User, Validator } from './entity';
 
 const validator = Validator();
 
@@ -33,16 +34,19 @@ export type DAOEntity = Baseline & {
 export type DAOConsenter = Baseline & {
   read(parms?:ReadParms):Promise<(Consenter|null)|Consenter[]>
 }
+export type DAOConfig = Baseline & {
+  read(parms?:ReadParms):Promise<(Config|null)|Config[]>
+}
 
 export type FactoryParms = {
-  DAOType: 'user' | 'entity' | 'invitation' | 'consenter',
+  DAOType: 'user' | 'entity' | 'invitation' | 'consenter' | 'config',
   Payload: any
 }
 
 export class DAOFactory {
   constructor() { }
   
-  public static getInstance(parms:FactoryParms): DAOUser|DAOInvitation|DAOEntity|DAOConsenter {
+  public static getInstance(parms:FactoryParms): DAOUser|DAOInvitation|DAOEntity|DAOConsenter|DAOConfig {
     switch(parms.DAOType) {
 
       case 'user':
@@ -80,6 +84,9 @@ export class DAOFactory {
           throw new Error(`Consenter crud error: Invalid Y/N active field value specified in ${JSON.stringify(parms, null, 2)}: ${active}`);
         }
         return ConsenterCrud(parms.Payload as Consenter);
+
+      case 'config':
+        return ConfigCrud(parms.Payload as Config);
     }
   }
 }

--- a/lib/lambda/_lib/dao/db-update-builder.config.ts
+++ b/lib/lambda/_lib/dao/db-update-builder.config.ts
@@ -1,0 +1,35 @@
+import { AttributeValue } from "@aws-sdk/client-dynamodb";
+import { Builder, utils } from "./db-update-builder-utils";
+import { Config, ConfigFields } from "./entity";
+
+
+/**
+ * Create the command to modify an config item in the target table, or add a new one if it does not exist.
+ * @param TableName 
+ * @param config 
+ * @returns 
+ */
+export const configUpdate = (TableName:string, config:Config):Builder => {
+  const { getBlankItem, getFldSetStatement, wrap } = utils;
+  const buildUpdateItem = () => {
+    if( ! config.update_timestamp) {
+      config.update_timestamp = new Date().toISOString();
+    }
+    const key = {
+      [ ConfigFields.name ]: { S: config.name }
+    } as Record<string, AttributeValue>;
+    const item = getBlankItem(TableName, key);
+    const fieldset = [] as any[];
+    let fld: keyof typeof ConfigFields;
+    for(fld in ConfigFields) {
+      if(key[fld]) continue;
+      if( ! config[fld]) continue;
+      item.ExpressionAttributeValues![`:${fld}`] = wrap(config[fld]);
+      item.ExpressionAttributeNames![`#${fld}`] = fld;
+      fieldset.push({ [`#${fld}`]: `:${fld}`})
+    }
+    item.UpdateExpression = `SET ${fieldset.map((o:any) => { return getFldSetStatement(o); }).join(', ')}`
+    return item;
+  }
+  return { buildUpdateItem };
+};

--- a/lib/lambda/_lib/dao/entity.ts
+++ b/lib/lambda/_lib/dao/entity.ts
@@ -142,6 +142,47 @@ export type Invitation = {
   retracted_timestamp?: string,
 }
 
+/**************** CONFIG ****************/
+export enum ConfigNames { 
+  CONSENT_EXPIRATION = 'consent-expiration',
+  AUTH_IND_NBR = 'auth-ind-nbr',
+  FIRST_REMINDER = 'first-reminder',
+  SECOND_REMINDER = 'second-reminder',
+  THIRD_REMINDER = 'third-reminder',
+  FOURTH_REMINDER = 'fourth-reminder',
+  DELETE_EXHIBIT_FORMS_AFTER = 'delete-exhibit-forms-after',
+  DELETE_DRAFTS_AFTER = 'delete-drafts-after'
+}
+export type ConfigName = 
+  ConfigNames.CONSENT_EXPIRATION |
+  ConfigNames.AUTH_IND_NBR | 
+  ConfigNames.DELETE_DRAFTS_AFTER | 
+  ConfigNames.DELETE_EXHIBIT_FORMS_AFTER | 
+  ConfigNames.FIRST_REMINDER |
+  ConfigNames.SECOND_REMINDER |
+  ConfigNames.THIRD_REMINDER |
+  ConfigNames.FOURTH_REMINDER;
+export enum ConfigTypes {
+  DURATION = 'duration',
+  NUMBER = 'number',
+  STRING = 'string'
+}
+export type ConfigType = ConfigTypes.DURATION | ConfigTypes.NUMBER | ConfigTypes.STRING;
+export enum ConfigFields {
+  name = 'name',
+  value = 'value',
+  config_type = 'config_type',
+  description = 'description',
+  update_timestamp = 'update_timestamp'
+}
+export type Config = {
+  name: ConfigName,
+  value: string,
+  config_type: ConfigType,
+  description: string,
+  update_timestamp?: string
+}
+
 export function Validator() {
   const isRole = (role:string|undefined|null) => {
     if( ! role) return false;

--- a/lib/lambda/functions/Utils.ts
+++ b/lib/lambda/functions/Utils.ts
@@ -1,6 +1,7 @@
 import { CloudFrontClient, DistributionSummary, ListDistributionsCommand, ListDistributionsResult } from "@aws-sdk/client-cloudfront";
 import { DAOEntity, DAOFactory, DAOInvitation, DAOUser } from "../_lib/dao/dao";
 import { Entity, Invitation, User, YN } from "../_lib/dao/entity";
+import { exec } from "child_process";
 
 export type LambdaProxyIntegrationResponse<T extends string = string> = {
   isBase64Encoded: boolean;
@@ -210,4 +211,36 @@ export const debugLog = (o:any) => {
   if(process.env.DEBUG == 'true') {
     log(o);
   }
+}
+
+export const viewHtml = async (html:string) => {
+  const { writeFileSync } = await import('fs');
+  const { join } = await import('path');
+  const { tmpdir } = await import('os');
+  const { platform } = await import('process');
+
+  const tmpPath = join(tmpdir(), 'html_table.html');
+  let command = '';
+  switch (platform) {
+    case 'win32':
+      command = `start "" "${tmpPath}"`;
+      break;
+    case 'darwin':
+      command = `open "${tmpPath}"`;
+      break;
+    case 'linux':
+      command = `xdg-open "${tmpPath}"`;
+      break;
+    default:
+      console.error('Unsupported platform:', platform);
+      return;
+  }
+
+  writeFileSync(tmpPath, html, 'utf-8');
+  exec(command, (err) => {
+    if (err) {
+      console.error('Failed to open browser:', err);
+    }
+  });
+
 }

--- a/lib/lambda/functions/sys-admin/DynamoDbTableOutput.ts
+++ b/lib/lambda/functions/sys-admin/DynamoDbTableOutput.ts
@@ -1,0 +1,81 @@
+import { AttributeValue, DynamoDBClient, ScanCommand, ScanInput, ScanOutput } from "@aws-sdk/client-dynamodb";
+import { View } from "./view/View";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { convertFromApiObject } from "../../_lib/dao/db-object-builder";
+import { DynamoDbConstruct } from "../../../DynamoDb";
+import { HtmlTableView } from "./view/HtmlTableView";
+import { viewHtml } from "../Utils";
+
+/**
+ * Output a "display" of the entire content of the specified dynamodb table that is based on the
+ * output of the particular view provided.
+ */
+export class DynamoDbTableOutput {
+  private view: View;
+
+  constructor(view:View) {
+    this.view = view;
+  }
+
+  /**
+   * Get the entire dynamodb table content as 
+   * @param TableName 
+   * @returns 
+   */
+  private getTableScan = async (TableName:string):Promise<ScanOutput> => {
+    const dbclient = new DynamoDBClient({ region: process.env.REGION });
+    const docClient = DynamoDBDocumentClient.from(dbclient);
+    const command = new ScanCommand({ TableName, Limit: 200 } as ScanInput);
+    return docClient.send(command);
+  }
+
+  /**
+   * Convert the dynamodb table items into an html table.
+   * @param tableName 
+   * @returns 
+   */
+  public getDisplay = async (tableName:string):Promise<string> => {
+    const { view, getTableScan } = this;
+    const scanOutput = await getTableScan(tableName);
+    const converted = scanOutput.Items?.map((item:Record<string, AttributeValue>) => {
+      return convertFromApiObject(item, false);
+    });
+    return view.render(converted);
+  }
+}
+
+
+
+/**
+ * RUN MANUALLY:
+ */
+const { argv:args } = process;
+
+if(args.length > 2 && args[2] == 'RUN_MANUALLY_DYNAMODB_DISPLAY') {
+  const table = args[3];
+
+  let tableName;
+  switch(table) {
+    case 'user': tableName = DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME; break;
+    case 'entity': tableName = DynamoDbConstruct.DYNAMODB_ENTITY_TABLE_NAME; break;
+    case 'invitation': tableName = DynamoDbConstruct.DYNAMODB_INVITATION_EMAIL_INDEX; break;
+    case 'cp': tableName = DynamoDbConstruct.DYNAMODB_CONSENTER_TABLE_NAME; break;
+  }
+
+  if( ! tableName) {
+    console.error('Missing tableName parameter');
+    process.exit(0);
+  }
+
+  (async () => {
+    
+    const html = await new DynamoDbTableOutput(
+      new HtmlTableView()
+    ).getDisplay(tableName);
+
+    console.log(html)
+    
+    await viewHtml(html);
+  })();
+
+}

--- a/lib/lambda/functions/sys-admin/SysAdminUser.ts
+++ b/lib/lambda/functions/sys-admin/SysAdminUser.ts
@@ -136,7 +136,7 @@ export const getDbTable = async (parms:any):Promise<LambdaProxyIntegrationRespon
  * @returns The full set of application configurations.
  */
 export const getAppConfigs = async ():Promise<LambdaProxyIntegrationResponse> => {
-  const configs = new Configurations().getAppConfigs();
+  const configs = await new Configurations().getAppConfigs();
   return okResponse('Ok', { configs });
 }
 
@@ -146,7 +146,7 @@ export const getAppConfigs = async ():Promise<LambdaProxyIntegrationResponse> =>
  */
 export const getAppConfig = async (parms:any):Promise<LambdaProxyIntegrationResponse> => {
   const { name } = parms;
-  const config = new Configurations().getAppConfig(name);
+  const config = await new Configurations().getAppConfig(name);
   return okResponse('Ok', { config });
 }
 

--- a/lib/lambda/functions/sys-admin/view/AbstractTableView.ts
+++ b/lib/lambda/functions/sys-admin/view/AbstractTableView.ts
@@ -1,0 +1,82 @@
+import { View } from "./View";
+
+/**
+ * This abstract class performs the boilerplate tasks of iterating an array of objects to convert it
+ * into a tabular view. While this class builds the basic structure and order of the table for row and
+ * cell content, implementers of this class will inject the markup for how those rows and cells are defined.  
+ */
+export abstract class AbstractTableView implements View {
+  protected a?:any[];
+  protected header:Set<string> = new Set<string>;
+  protected joinVal = "";
+  protected offset:number = 0;
+  
+  protected abstract renderTable(content:string):string
+  protected abstract renderRow(content:string):string
+  protected abstract renderCell(content:string|null):string
+  protected abstract renderHeaderCell(content:string):string
+
+  /**
+   * Build a set that compiles each key of each object found in the main array of objects.
+   * All attributes are accounted for, but - as a set - only once. The distinct nature of
+   * the set is appropriate for the header.
+   */
+  private buildHeader = () => {
+    const { a=[], header } = this;
+    for(let i=0; i<a.length; i++) {
+      const obj = a[i];
+      for (const key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          header.add(key)          
+        }
+      }
+    }
+  }
+
+  /**
+   * @param _a 
+   * @returns The rendered output, a conversion of the supplied array of objects into a tabluar view. 
+   */
+  public render = (_a?:any[]): string => {
+    this.a = _a ?? (this.a ?? []);
+    const { buildHeader, render, renderTable, renderRow, renderCell, renderHeaderCell, a, header, joinVal } = this;
+
+    buildHeader();
+
+    const renderedRows:string[] = [];
+    let renderedCells:string[] = [];
+
+    // Render the header row
+    for(const key of header) {
+      renderedCells.push(renderHeaderCell(key));
+    }
+    renderedRows.push(renderRow(renderedCells.join(joinVal)));
+
+    // Render the remaining rows
+    for(let i=0; i<a.length; i++) {
+      const obj = a[i];
+      renderedCells = [] as string[];    
+      for(const key of header) {
+        const fldval = obj[key];
+        if(typeof fldval === 'object') {
+          let content = null;
+          this.offset++;
+          if(fldval instanceof Array) {
+            content = render(fldval);
+          }
+          else {
+            content = render([fldval]);
+          }
+          this.offset--;
+          renderedCells.push(renderCell(content));
+        }
+        else {
+          renderedCells.push(renderCell(fldval as string ?? null));
+        }
+      }
+      renderedRows.push(renderRow(renderedCells.join(joinVal)));
+    }
+    
+    return renderTable(renderedRows.join(joinVal));
+  }
+}

--- a/lib/lambda/functions/sys-admin/view/HtmlTableView.ts
+++ b/lib/lambda/functions/sys-admin/view/HtmlTableView.ts
@@ -1,0 +1,123 @@
+import { viewHtml } from "../../Utils";
+import { AbstractTableView } from "./AbstractTableView";
+
+/**
+ * This class converts an array of objects into an html table rowset
+ */
+export class HtmlTableView extends AbstractTableView {
+  constructor(a?:any[]) {
+    super();
+    this.a = a;
+    this.joinVal = "\n";
+  }
+
+  protected renderTable = (content:string): string => {
+    const { joinVal:jv } = this;
+    // const styles = {
+    //   ['font-family']: 'helvetica',
+    //   ['font-size']: '10px'
+    // }
+    // const style = Object.entries(styles).map(entry => `${entry[0]}:${entry[1]};`).join('');
+
+    const style = `<style>
+      table.dbTable, table.dbTable th, table.dbTable td {
+        border: 1px solid black;
+        border-collapse: collapse;
+        font-size: 10px;
+        font-family: helvetica;
+      }
+      table.dbTable th {
+        color: white;
+        background-color: black;
+        border-left: 1px solid white;
+        border-right: 1px solid white;
+      }
+      table.dbTable th:first-child {
+        border-left: 1px solid black;
+      }
+      table.dbTable th:last-child {
+        border-right: 1px solid black;
+      }
+      table.dbTable td, th {
+        padding: 2px;
+      }
+      pre.dbTable:hover {
+        cursor: pointer;
+        font-weight: bold;  
+      }
+    </style>
+    <script>
+      function showHide() {
+        const { children } = event.srcElement.parentElement;
+        const hiding = children[0].innerText.includes('+');  
+        children[0].innerText = hiding ? '-{...}' : '+{...}';
+        children[1].style.display = hiding ? 'inline' : 'none';
+      }
+    </script>
+    `;
+
+    if(this.offset == 0) {
+      return `${style}${jv}<table class='dbtable'>${jv}${content}${jv}</table>`;
+    }
+    else {
+      return `${jv}<pre  class='dbtable' onclick='showHide();'>+{...}</pre><table style='display:none;' class='dbtable'>${jv}${content}${jv}</table>`;
+    }  
+  }
+
+  protected renderRow = (content:string): string => {
+    const { joinVal:jv } = this;
+    return `<tr>${jv}${content}${jv}</tr>`;
+  }
+
+  protected renderCell = (content:string): string => {
+    const padLeft = "  ".repeat(this.offset + 1);
+    return `${padLeft}<td>${content ?? '&nbsp;'}</td>`
+  }
+
+  protected renderHeaderCell = (content:string): string => {
+    const padLeft = "  ".repeat(this.offset + 1);
+    return `${padLeft}<th style='text-align:center; font-weight:bold;'>${content}</th>`;
+  }
+}
+
+
+/**
+ * RUN MANUALLY:
+ */
+const { argv:args } = process;
+import { exec } from 'child_process';
+
+if(args.length > 2 && args[2] == 'RUN_MANUALLY_TABLE_VIEW') {
+
+  const getArray = (): any[] => {
+    return [
+      { 
+        fruit: 'apple',
+        vegetable: 'spinach',
+        grain: 'wheat'
+      },
+      {
+        grain: 'rye',
+        meat: 'chicken',
+        drink: 'beer'
+      },
+      {
+        dessert: 'ice cream',
+        fruit: 'orange',
+      }
+    ] as any[];
+  } 
+
+  const a = getArray();
+  a[1].nested = getArray();
+  a[1].nested[1].nested = getArray();
+
+  const view = new HtmlTableView(a);
+  const html = view.render();
+  console.log(html);
+
+  (async () => {
+    await viewHtml(html);
+  })();
+}
+

--- a/lib/lambda/functions/sys-admin/view/View.ts
+++ b/lib/lambda/functions/sys-admin/view/View.ts
@@ -1,0 +1,7 @@
+/**
+ * Topmost interface for a view
+ */
+export type View = {
+  render(a?:any[]):string
+};
+

--- a/lib/role/AuthorizedIndividual.ts
+++ b/lib/role/AuthorizedIndividual.ts
@@ -7,6 +7,7 @@ import { AbstractFunction } from "../AbstractFunction";
 import { ApiConstructParms } from "../Api";
 import { Roles } from "../lambda/_lib/dao/entity";
 import { AbstractRole, AbstractRoleApi } from "./AbstractRole";
+import { Configurations } from "../lambda/_lib/config/Config";
 
 
 export class AuthorizedIndividualApi extends AbstractRole {
@@ -105,7 +106,8 @@ export class LambdaFunction extends AbstractFunction {
       }),
       environment: {
         REGION: scope.node.getContext('stack-parms').REGION,
-        USERPOOL_ID: userPoolId
+        USERPOOL_ID: userPoolId,
+        [Configurations.ENV_VAR_NAME]: new Configurations(context.CONFIG).getJson()
       }
     });
   }

--- a/lib/role/ConsentingPerson.ts
+++ b/lib/role/ConsentingPerson.ts
@@ -7,6 +7,7 @@ import { Roles } from "../lambda/_lib/dao/entity";
 import { AbstractRole, AbstractRoleApi } from "./AbstractRole";
 import { Effect, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { IContext } from "../../contexts/IContext";
+import { Configurations } from "../lambda/_lib/config/Config";
 
 export class ConsentingPersonApi extends AbstractRole {
   private api: AbstractRoleApi
@@ -100,7 +101,8 @@ export class LambdaFunction extends AbstractFunction {
       environment: {
         REGION: scope.node.getContext('stack-parms').REGION,
         CLOUDFRONT_DOMAIN: cloudfrontDomain,
-        USERPOOL_ID: userPoolId
+        USERPOOL_ID: userPoolId,
+        [Configurations.ENV_VAR_NAME]: new Configurations(context.CONFIG).getJson()
       }
     });
   }

--- a/lib/role/ReAdmin.ts
+++ b/lib/role/ReAdmin.ts
@@ -6,6 +6,7 @@ import { IContext } from '../../contexts/IContext';
 import { AbstractFunction } from "../AbstractFunction";
 import { Roles } from '../lambda/_lib/dao/entity';
 import { AbstractRole, AbstractRoleApi } from "./AbstractRole";
+import { Configurations } from "../lambda/_lib/config/Config";
 
 export interface AdminUserParms {
   userPool: UserPool, 
@@ -110,7 +111,8 @@ export class LambdaFunction extends AbstractFunction {
       environment: {
         REGION: context.REGION,
         CLOUDFRONT_DOMAIN: cloudfrontDomain,
-        USERPOOL_ID: userPoolId
+        USERPOOL_ID: userPoolId,
+        [Configurations.ENV_VAR_NAME]: new Configurations(context.CONFIG).getJson()
       }
     });
   }

--- a/lib/role/SysAdmin.ts
+++ b/lib/role/SysAdmin.ts
@@ -7,6 +7,7 @@ import { AbstractFunction } from "../AbstractFunction";
 import { ApiConstructParms } from "../Api";
 import { Roles } from '../lambda/_lib/dao/entity';
 import { AbstractRole, AbstractRoleApi } from "./AbstractRole";
+import { Configurations } from "../lambda/_lib/config/Config";
 
 export class SysAdminApi extends AbstractRole {
   private api: AbstractRoleApi;
@@ -18,7 +19,6 @@ export class SysAdminApi extends AbstractRole {
 
     const { userPool, cloudfrontDomain } = parms;
     const lambdaFunction = new LambdaFunction(scope, `${constructId}Lambda`, parms);
-    
 
     this.api = new AbstractRoleApi(scope, `${constructId}Api`, {
       cloudfrontDomain,
@@ -58,6 +58,8 @@ export class SysAdminApi extends AbstractRole {
 export class LambdaFunction extends AbstractFunction {
   constructor(scope: Construct, constructId: string, parms:ApiConstructParms) {
     const context:IContext = scope.node.getContext('stack-parms');
+    const { CONFIG, REGION } = context;
+    const config = new Configurations(CONFIG);
     const { userPool, userPoolName, userPoolDomain, cloudfrontDomain, redirectPath } = parms;
     const { userPoolArn } = userPool;
     const redirectURI = `${cloudfrontDomain}/${redirectPath}`.replace('//', '/');
@@ -107,7 +109,8 @@ export class LambdaFunction extends AbstractFunction {
         }
       }),
       environment: {
-        REGION: context.REGION,
+        REGION,
+        [Configurations.ENV_VAR_NAME]: config.getJson(),
         USERPOOL_NAME: userPoolName,
         COGNITO_DOMAIN: userPoolDomain,
         CLOUDFRONT_DOMAIN: cloudfrontDomain,


### PR DESCRIPTION
This feature adds two capabilities through the sysadmin role for use by QA testers:

1. A dynamo database table viewer. Introduces a new tab in the sysadmin console of the app with a refreshable html table grid for each database table. Includes a new api task for at the sysadmin rest endpoint for refreshing the display.
2. A database driven alternative for app configurations, where configurations that have been originally set in the context.json file for the CDK app are also accessible and modifiable as entries in a dynamodb table. This is useful for QA testers who want to modify the configuration values, like durations and timeouts, to shorten them so as to speed up testing by "shrinking time". 