### PR TITLE
Unique names

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Build the entire application and AWS infrastructure from scratch.
      "STACK_ID": "ett",
      "ACCOUNT": "[Your account ID]",
      "REGION": "[Your desired region]",
-     "BUCKET_NAME": "ett-static-site-content",
      "CONFIG": {
        "useDatabase": true,
        "configs": [
@@ -49,7 +48,6 @@ Build the entire application and AWS infrastructure from scratch.
    }
    ```
    
-   *NOTE: Make sure the BUCKET_NAME value does not collide with an existing bucket.*
    The "CONFIG" entry is a collection of settings the app will use for reference when carrying out certain business rules. These are mostly duration or timeout thresholds. There is a "useDatabase" setting provided
    
    - "true": These configuration values will be loaded into a database table and the lambda functions that drive the app logic will obtain them from there. Also, the sysadmin user will be provided a tab that can be used to modify these values *(useful for testing - no stack update necessary)*.

--- a/bin/EttApp.ts
+++ b/bin/EttApp.ts
@@ -17,28 +17,22 @@ const context:IContext = <IContext>ctx;
 
 const app = new App();
 app.node.setContext('stack-parms', context);
-const stackName = `${context.STACK_ID}-${context.TAGS.Landscape}`;
+const { STACK_ID, ACCOUNT:account, REGION:region, TAGS: { Function, Landscape, Service }, SCENARIO:scenario } = context;
+const stackName = `${STACK_ID}-${Landscape}`;
 
 const stackProps: StackProps = {
   stackName,
   description: 'Ethical transparency tool',
-  env: {
-    account: context.ACCOUNT,
-    region: context.REGION
-  },
-  tags: {
-    Service: context.TAGS.Service,
-    Function: context.TAGS.Function,
-    Landscape: context.TAGS.Landscape
-  }
+  env: { account, region },
+  tags: { Service, Function, Landscape }
 }
 
 const stack:AbstractStack = new AbstractStack(app, stackName, stackProps);
 
 // Adding tags into the stackProps does not seem to work - have to apply tags using aspects:
-Tags.of(stack).add('Service', context.TAGS.Service);
-Tags.of(stack).add('Function', context.TAGS.Function);
-Tags.of(stack).add('Landscape', context.TAGS.Landscape);
+Tags.of(stack).add('Service', Service);
+Tags.of(stack).add('Function', Function);
+Tags.of(stack).add('Landscape', Landscape);
 
 const buildAll = () => {
   // Set up the bucket only.
@@ -66,7 +60,8 @@ const buildAll = () => {
     userPool: cognito.getUserPool(),
     userPoolName: cognito.getUserPoolName(),    
     cloudfrontDomain: cloudfront.getDistributionDomainName(),
-    redirectPath: 'index.htm'
+    redirectPath: 'index.htm',
+    landscape: Landscape
   } as ApiConstructParms);
 
   // Grant the apis the necessary permissions (policy actions).
@@ -79,7 +74,7 @@ const buildAll = () => {
     distributionId: cloudfront.getDistributionId(),
     cloudfrontDomain: cloudfront.getDistributionDomainName(),
     cognitoDomain: cognito.getUserPoolDomain(),
-    cognitoUserpoolRegion: context.REGION,
+    cognitoUserpoolRegion: region,
     entityAcknowledgeApiUri: signupApi.entityAcknowledgeApiUri,
     registerEntityApiUri: signupApi.registerEntityApiUri,
     registerConsenterApiUri: signupApi.registerConsenterApiUri,
@@ -131,7 +126,7 @@ const buildDynamoDb = (): DynamoDbConstruct => {
   return db;
 }
 
-switch(context.SCENARIO) {
+switch(scenario) {
   case SCENARIO.DEFAULT:
     buildAll();
     break;

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -1,0 +1,3 @@
+stackId="$(jq -r '.STACK_ID' ./contexts/context.json)"
+landscape="$(jq -r '.TAGS.Landscape' ./contexts/context.json)"
+sh -c "aws s3 cp ./frontend/index.htm s3://${stackId}-${landscape}-static-site-content/"

--- a/contexts/IContext.ts
+++ b/contexts/IContext.ts
@@ -5,7 +5,6 @@ export interface IContext {
   STACK_ID: string;
   ACCOUNT:  string;
   REGION:   string;
-  BUCKET_NAME: string;
   CLOUDFRONT_DOMAIN?: string;
   CLOUDFRONT_CERTIFICATE?: string;
   CONFIG: CONFIG;

--- a/contexts/context.json
+++ b/contexts/context.json
@@ -3,7 +3,6 @@
   "STACK_ID": "ett",
   "ACCOUNT": "037860335094",
   "REGION": "us-east-2",
-  "BUCKET_NAME": "ett-static-site-content",
   "CONFIG": {
     "useDatabase": true,
     "configs": [

--- a/lib/Api.ts
+++ b/lib/Api.ts
@@ -14,6 +14,7 @@ export type ApiConstructParms = {
   userPoolDomain: string,
   cloudfrontDomain: string,
   redirectPath: string,
+  landscape: string
 }
 
 /**

--- a/lib/Cloudfront.ts
+++ b/lib/Cloudfront.ts
@@ -23,13 +23,14 @@ export class CloudfrontConstruct extends Construct {
 
     this.constructId = constructId;
     this.context = scope.node.getContext('stack-parms');
+    const { TAGS: { Landscape:landscape }} = this.context;
     const  defaultBehavior = { 
       origin: new HttpOrigin('dummy-origin.com', { originId: 'dummy-origin' })
     }
 
     this.distribution = new Distribution(this, 'Distribution', {
       defaultBehavior,
-      comment: `ett-${this.context.TAGS.Landscape}-distribution`,
+      comment: `ett-${landscape}-distribution`,
       defaultRootObject: 'index.htm',
       logBucket: new Bucket(this, 'DistributionLogsBucket', {
         removalPolicy: RemovalPolicy.DESTROY,    
@@ -47,7 +48,7 @@ export class CloudfrontConstruct extends Construct {
 
     const oac = new CfnOriginAccessControl(this, 'StaticSiteAccessControl', {
       originAccessControlConfig: {
-        name: 'ett-static-site',
+        name: `ett-${landscape}-static-site`,
         originAccessControlOriginType: 's3',
         signingBehavior: 'always',
         signingProtocol: 'sigv4',

--- a/lib/Cognito.ts
+++ b/lib/Cognito.ts
@@ -6,7 +6,7 @@ import { AbstractFunction } from './AbstractFunction';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import path = require('path');
 import { Effect, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { DynamoDbConstruct } from './DynamoDb';
+import { DynamoDbConstruct, TableBaseNames } from './DynamoDb';
 import { Configurations } from './lambda/_lib/config/Config';
 
 export class CognitoConstruct extends Construct {
@@ -28,23 +28,29 @@ export class CognitoConstruct extends Construct {
   }
 
   buildResources(): void {
+    const { REGION, ACCOUNT } = this.context;
+    const { CONFIG, CONSENTERS, ENTITIES, INVITATIONS, USERS } = TableBaseNames;
+    const { getTableName } = DynamoDbConstruct;
 
     const dynamodbResources = [
-      `arn:aws:dynamodb:${this.context.REGION}:${this.context.ACCOUNT}:table/${DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME}`,
-      `arn:aws:dynamodb:${this.context.REGION}:${this.context.ACCOUNT}:table/${DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME}/*`,
-      `arn:aws:dynamodb:${this.context.REGION}:${this.context.ACCOUNT}:table/${DynamoDbConstruct.DYNAMODB_INVITATION_TABLE_NAME}`,
-      `arn:aws:dynamodb:${this.context.REGION}:${this.context.ACCOUNT}:table/${DynamoDbConstruct.DYNAMODB_INVITATION_TABLE_NAME}/*`,
-      `arn:aws:dynamodb:${this.context.REGION}:${this.context.ACCOUNT}:table/${DynamoDbConstruct.DYNAMODB_ENTITY_TABLE_NAME}`,
-      `arn:aws:dynamodb:${this.context.REGION}:${this.context.ACCOUNT}:table/${DynamoDbConstruct.DYNAMODB_ENTITY_TABLE_NAME}/*`,
-      `arn:aws:dynamodb:${this.context.REGION}:${this.context.ACCOUNT}:table/${DynamoDbConstruct.DYNAMODB_CONSENTER_TABLE_NAME}`,
-      `arn:aws:dynamodb:${this.context.REGION}:${this.context.ACCOUNT}:table/${DynamoDbConstruct.DYNAMODB_CONSENTER_TABLE_NAME}/*`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(USERS)}`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(USERS)}/*`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(INVITATIONS)}`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(INVITATIONS)}/*`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(ENTITIES)}`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(ENTITIES)}/*`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(CONSENTERS)}`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(CONSENTERS)}/*`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(CONFIG)}`,
+      `arn:aws:dynamodb:${REGION}:${ACCOUNT}:table/${getTableName(CONFIG)}/*`,
     ] as string[];
 
     const environment = {
-      DYNAMODB_USER_TABLE_NAME: DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME,
-      DYNAMODB_INVITATION_TABLE_NAME: DynamoDbConstruct.DYNAMODB_INVITATION_TABLE_NAME,
-      DYNAMODB_ENTITY_TABLE_NAME: DynamoDbConstruct.DYNAMODB_ENTITY_TABLE_NAME,
-      DYNAMODB_CONSENTER_TABLE_NAME: DynamoDbConstruct.DYNAMODB_CONSENTER_TABLE_NAME,
+      DYNAMODB_USER_TABLE_NAME: getTableName(USERS),
+      DYNAMODB_INVITATION_TABLE_NAME: getTableName(INVITATIONS),
+      DYNAMODB_ENTITY_TABLE_NAME: getTableName(ENTITIES),
+      DYNAMODB_CONSENTER_TABLE_NAME: getTableName(CONSENTERS),
+      DYNAMODB_CONFIG_TABLE_NAME: getTableName(CONFIG),
       [Configurations.ENV_VAR_NAME]: new Configurations(this.context.CONFIG).getJson() 
     };
 
@@ -121,7 +127,7 @@ export class CognitoConstruct extends Construct {
               actions: [
                 'cognito-idp:AdminDeleteUser',
               ],
-              resources: [ `arn:aws:cognito-idp:${this.context.REGION}:${this.context.ACCOUNT}:userpool/${this.context.REGION}_*` ],
+              resources: [ `arn:aws:cognito-idp:${REGION}:${ACCOUNT}:userpool/${REGION}_*` ],
               effect: Effect.ALLOW
             })]
           }),

--- a/lib/SignupApi.ts
+++ b/lib/SignupApi.ts
@@ -53,7 +53,7 @@ export class SignupApiConstruct extends Construct {
    * Create the lambda function and api for checking invitation code and registering a new user has acknowledged privacy policy.
    */
   private createAcknowledgeEntityApi = () => {
-    const { constructId, parms: { cloudfrontDomain }, stageName, context: { REGION } } = this;
+    const { constructId, parms: { cloudfrontDomain }, stageName, context: { REGION, CONFIG, TAGS: { Landscape:landscape } } } = this;
     const basename = `${constructId}AcknowledgeEntity`;
     const description = 'for checking invitation code and registering a new user has acknowledged privacy policy';
 
@@ -63,7 +63,7 @@ export class SignupApiConstruct extends Construct {
       memorySize: 1024,
       entry: 'lib/lambda/functions/signup/EntityAcknowledgement.ts',
       // handler: 'handler',
-      functionName: `Ett${basename}`,
+      functionName: `ett-${landscape}-signup-acknowledge-entity-lambda`,
       description: `Function ${description}`,
       cleanup: true,
       bundling: {
@@ -74,7 +74,7 @@ export class SignupApiConstruct extends Construct {
       environment: {
         REGION,
         CLOUDFRONT_DOMAIN: cloudfrontDomain,
-        [Configurations.ENV_VAR_NAME]: new Configurations(this.context.CONFIG).getJson()
+        [Configurations.ENV_VAR_NAME]: new Configurations(CONFIG).getJson()
       }
     });
 
@@ -84,7 +84,7 @@ export class SignupApiConstruct extends Construct {
         description: `API ${description}`,
         stageName
       },
-      restApiName: `Ett-${basename}-rest-api`,
+      restApiName: `ett-${landscape}-signup-acknowledge-entity-rest-api`,
       handler: this.acknowledgeEntityLambda,
       proxy: false
     });
@@ -112,7 +112,7 @@ export class SignupApiConstruct extends Construct {
    * Create the lambda function and api for for checking invitation code and registering a new user has signed and registered.
    */
   private createRegisterEntityApi = () => {
-    const { constructId, context: { REGION, ACCOUNT }, 
+    const { constructId, context: { REGION, ACCOUNT, CONFIG, TAGS: { Landscape:landscape } }, 
       parms: { cloudfrontDomain, userPool: { userPoolArn, userPoolId } }, stageName 
     } = this;
     const basename = `${constructId}RegisterEntity`;
@@ -124,7 +124,7 @@ export class SignupApiConstruct extends Construct {
       memorySize: 1024,
       entry: 'lib/lambda/functions/signup/EntityRegistration.ts',
       // handler: 'handler',
-      functionName: `Ett${basename}`,
+      functionName: `ett-${landscape}-signup-register-entity-lambda`,
       description: `Function ${description}`,
       cleanup: true,
       bundling: {
@@ -167,7 +167,7 @@ export class SignupApiConstruct extends Construct {
         REGION,
         CLOUDFRONT_DOMAIN: cloudfrontDomain,
         USERPOOL_ID: userPoolId,
-        [Configurations.ENV_VAR_NAME]: new Configurations(this.context.CONFIG).getJson()
+        [Configurations.ENV_VAR_NAME]: new Configurations(CONFIG).getJson()
       }
     });
 
@@ -177,7 +177,7 @@ export class SignupApiConstruct extends Construct {
         description: `API ${description}`,
         stageName: stageName
       },
-      restApiName: `Ett-${basename}-rest-api`,
+      restApiName: `ett-${landscape}-signup-register-entity-rest-api`,
       handler: this.registerEntityLambda,
       proxy: false
     });
@@ -205,7 +205,7 @@ export class SignupApiConstruct extends Construct {
    * Create the public registration lambda function and api for the first stage of consenter registration
    */
   private createRegisterConsenterApi = () => {
-    const { constructId, parms: { cloudfrontDomain }, stageName, context: { REGION } } = this;
+    const { constructId, parms: { cloudfrontDomain }, stageName, context: { REGION, CONFIG, TAGS: { Landscape:landscape } } } = this;
     const basename = `${constructId}RegisterConsenter`;
     const description = 'for the first stage of public registration of a consenting person';
 
@@ -215,7 +215,7 @@ export class SignupApiConstruct extends Construct {
       memorySize: 1024,
       entry: 'lib/lambda/functions/signup/ConsenterRegistration.ts',
       // handler: 'handler',
-      functionName: `Ett${basename}`,
+      functionName: `ett-${landscape}-signup-register-consenter-lambda`,
       description: `Function ${description}`,
       cleanup: true,
       bundling: {
@@ -236,7 +236,7 @@ export class SignupApiConstruct extends Construct {
         description: `API ${description}`,
         stageName
       },
-      restApiName: `Ett-${basename}-rest-api`,
+      restApiName: `ett-${landscape}-signup-register-consenter-rest-api`,
       handler: this.registerConsenterLambda,
       proxy: false
     });

--- a/lib/StaticSite.ts
+++ b/lib/StaticSite.ts
@@ -31,14 +31,15 @@ export abstract class StaticSiteConstruct extends Construct {
 
   public abstract customize(): void;
  
-  public getBucket(): Bucket {
+  public getBucket = (): Bucket => {
+    const { TAGS: { Landscape }} = this.context;
     if( ! this.bucket) {
       if(this.props?.bucket) {
         this.bucket = this.props.bucket;
       }
       else {
         this.bucket = new Bucket(this, 'Bucket', {
-          bucketName: this.context.BUCKET_NAME,
+          bucketName: `ett-${Landscape}-static-site-content`,
           publicReadAccess: false,
           blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
           removalPolicy: RemovalPolicy.DESTROY,    
@@ -55,7 +56,7 @@ export abstract class StaticSiteConstruct extends Construct {
    * way into the bucket so as to modify it's content, a dependency to the corresponding resource(s)
    * needs to be applied to the BucketDeployment.
    */
-  public setIndexFileForUpload(dependOn?:Construct[]) {
+  public setIndexFileForUpload = (dependOn?:Construct[]) => {
     const deployment = new BucketDeployment(this, 'BucketContentDeployment', {
       destinationBucket: this.getBucket(),
       sources: [

--- a/lib/lambda/_lib/dao/dao-config.ts
+++ b/lib/lambda/_lib/dao/dao-config.ts
@@ -1,16 +1,19 @@
 import { BatchWriteItemCommand, BatchWriteItemInput, BatchWriteItemOutput, DeleteItemCommand, DeleteItemCommandInput, DeleteItemCommandOutput, DynamoDBClient, GetItemCommand, GetItemCommandInput, GetItemCommandOutput, ScanCommand, ScanInput, UpdateItemCommand, UpdateItemCommandInput, UpdateItemCommandOutput, WriteRequest } from "@aws-sdk/client-dynamodb";
-import { DAOConfig, ReadParms } from "./dao"
-import { Config, ConfigFields } from "./entity"
-import { DynamoDbConstruct } from "../../../DynamoDb";
-import { configUpdate } from "./db-update-builder.config";
-import { convertFromApiObject } from "./db-object-builder";
 import { marshall } from "@aws-sdk/util-dynamodb";
+import { DynamoDbConstruct, TableBaseNames } from "../../../DynamoDb";
+import { DAOConfig, ReadParms } from "./dao";
+import { convertFromApiObject } from "./db-object-builder";
+import { configUpdate } from "./db-update-builder.config";
+import { Config, ConfigFields } from "./entity";
 
 
 export function ConfigCrud(configInfo:Config, _dryRun:boolean=false): DAOConfig {
 
   const dbclient = new DynamoDBClient({ region: process.env.REGION });
-  const TableName = DynamoDbConstruct.DYAMODB_CONFIG_TABLE_NAME;
+  const { getTableName } = DynamoDbConstruct;
+  const { CONFIG } = TableBaseNames;
+  const TableName = getTableName(CONFIG);
+
   
   let { name, description, update_timestamp, value } = configInfo;
   
@@ -168,7 +171,10 @@ export type DAOConfigBatch = { create(configs:Config[]):Promise<any>, Delete(nam
 export function ConfigBatch(_dryRun:boolean=false): DAOConfigBatch {
 
   const dbclient = new DynamoDBClient({ region: process.env.REGION });
-  const TableName = DynamoDbConstruct.DYAMODB_CONFIG_TABLE_NAME;
+  const { getTableName } = DynamoDbConstruct;
+  const { CONFIG } = TableBaseNames;
+  const TableName = getTableName(CONFIG);
+
 
   /**
    * Put multiple items into the table as one operation

--- a/lib/lambda/_lib/dao/dao-consenter.ts
+++ b/lib/lambda/_lib/dao/dao-consenter.ts
@@ -1,16 +1,18 @@
 import { DeleteItemCommand, DeleteItemCommandInput, DeleteItemCommandOutput, DynamoDBClient, GetItemCommand, GetItemCommandInput, GetItemCommandOutput, PutItemCommandOutput, UpdateItemCommand, UpdateItemCommandInput, UpdateItemCommandOutput } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
-import { DynamoDbConstruct } from "../../../DynamoDb";
+import { DynamoDbConstruct, TableBaseNames } from "../../../DynamoDb";
 import { DAOConsenter, ReadParms } from "./dao";
-import { AffiliateTypes, Consenter, ConsenterFields, Roles, YN } from "./entity";
-import { consenterUpdate } from "./db-update-builder.consenter";
 import { convertFromApiObject } from "./db-object-builder";
+import { consenterUpdate } from "./db-update-builder.consenter";
+import { AffiliateTypes, Consenter, ConsenterFields, Roles, YN } from "./entity";
 
 export function ConsenterCrud(consenterInfo:Consenter, _dryRun:boolean=false): DAOConsenter {
 
   const dbclient = new DynamoDBClient({ region: process.env.REGION });
   const docClient = DynamoDBDocumentClient.from(dbclient);
-  const TableName = DynamoDbConstruct.DYNAMODB_CONSENTER_TABLE_NAME;
+  const { getTableName } = DynamoDbConstruct;
+  const { CONSENTERS } = TableBaseNames;
+  const TableName = getTableName(CONSENTERS);
   
   let { email, active=YN.Yes, firstname, middlename, lastname, exhibit_forms, 
     create_timestamp=(new Date().toISOString()), consented_timestamp, renewed_timestamp, rescinded_timestamp

--- a/lib/lambda/_lib/dao/dao-entity.test.ts
+++ b/lib/lambda/_lib/dao/dao-entity.test.ts
@@ -65,17 +65,6 @@ const testPut = () => {
 const testRead = () => {
   describe('Dao entity read', () => {
 
-    it('Should error if entity_id is missing', async () => {
-      expect(async () => {
-        const dao = DAOFactory.getInstance({
-          DAOType: 'entity', Payload: {
-            [EntityFields.entity_name]: 'Boston University'
-          }
-        }) as DAOEntity;
-        await dao.read();
-      }).rejects.toThrow(/Entity read error: Missing entity_id in /)
-    });
-
     it('Should return null if a non-existing entity_id is specified', async () => {
       const dao = DAOFactory.getInstance({
         DAOType: 'entity', Payload: {

--- a/lib/lambda/_lib/dao/dao-entity.ts
+++ b/lib/lambda/_lib/dao/dao-entity.ts
@@ -1,18 +1,21 @@
 import { DeleteItemCommand, DeleteItemCommandInput, DeleteItemCommandOutput, DynamoDBClient, GetItemCommand, GetItemCommandInput, GetItemCommandOutput, QueryCommand, QueryCommandInput, UpdateItemCommand, UpdateItemCommandInput, UpdateItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import { v4 as uuidv4 } from 'uuid';
+import { DynamoDbConstruct, IndexBaseNames, TableBaseNames } from '../../../DynamoDb';
 import { DAOEntity, ReadParms } from './dao';
 import { convertFromApiObject } from './db-object-builder';
 import { entityUpdate } from './db-update-builder.entity';
 import { Entity, EntityFields, YN } from './entity';
-import { DynamoDbConstruct } from '../../../DynamoDb';
 
 export const ENTITY_WAITING_ROOM:string = '__UNASSIGNED__';
 
 export function EntityCrud(entityInfo:Entity, _dryRun:boolean=false): DAOEntity {
 
   const dbclient = new DynamoDBClient({ region: process.env.REGION });
-  const TableName = DynamoDbConstruct.DYNAMODB_ENTITY_TABLE_NAME;
-  const TableActiveIndex = DynamoDbConstruct.DYNAMODB_ENTITY_ACTIVE_INDEX;
+  const { getTableName } = DynamoDbConstruct;
+  const { ENTITIES } = TableBaseNames;
+  const { ENTITIES_ACTIVE } = IndexBaseNames;
+  const TableName = getTableName(ENTITIES);
+  const TableActiveIndex = ENTITIES_ACTIVE;
 
   let { entity_id, entity_name, create_timestamp, update_timestamp, active=YN.Yes } = entityInfo;
 

--- a/lib/lambda/_lib/dao/dao-invitation.ts
+++ b/lib/lambda/_lib/dao/dao-invitation.ts
@@ -4,7 +4,7 @@ import { DAOInvitation, ReadParms } from './dao';
 import { convertFromApiObject } from './db-object-builder';
 import { invitationUpdate } from './db-update-builder.invitation';
 import { Invitation, InvitationFields } from './entity';
-import { DynamoDbConstruct } from '../../../DynamoDb';
+import { DynamoDbConstruct, IndexBaseNames, TableBaseNames } from '../../../DynamoDb';
 
 /**
  * Basic CRUD operations for the invitations table.
@@ -13,8 +13,10 @@ import { DynamoDbConstruct } from '../../../DynamoDb';
  */
 export function InvitationCrud(invitationInfo:Invitation, _dryRun:boolean=false): DAOInvitation {
   const dbclient = new DynamoDBClient({ region: process.env.REGION });
-  const TableName = DynamoDbConstruct.DYNAMODB_INVITATION_TABLE_NAME;
-  const TableEntityIndex = DynamoDbConstruct.DYNAMODB_INVITATION_ENTITY_INDEX;
+  const { getTableName } = DynamoDbConstruct;
+  const { INVITATIONS } = TableBaseNames;
+  const { INVITATIONS_ENTITY, INVITATIONS_EMAIL } = IndexBaseNames;
+  const TableName = getTableName(INVITATIONS);
 
   let { code:_code, entity_id, role, email } = invitationInfo;
 
@@ -110,7 +112,7 @@ export function InvitationCrud(invitationInfo:Invitation, _dryRun:boolean=false)
     // Declare QueryCommandInput fields
     let vals = {} as any;
     let cdns = '';
-    let index = 'EmailIndex';
+    let index = INVITATIONS_EMAIL;
 
     // Build QueryCommandInput fields
     if(email) {
@@ -125,7 +127,7 @@ export function InvitationCrud(invitationInfo:Invitation, _dryRun:boolean=false)
       else {
         cdns = `${InvitationFields.entity_id} = :v2`;
       }
-      if( ! email) index = TableEntityIndex;
+      if( ! email) index = INVITATIONS_ENTITY;
     }
 
     // Declare QueryCommandInput

--- a/lib/lambda/_lib/dao/dao-user.test.ts
+++ b/lib/lambda/_lib/dao/dao-user.test.ts
@@ -3,7 +3,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { DAOFactory, DAOUser } from './dao';
 import { Roles, User, UserFields, YN } from './entity';
-import { DynamoDbConstruct } from '../../../DynamoDb';
+import { DynamoDbConstruct, TableBaseNames } from '../../../DynamoDb';
 
 const dbMockClient = mockClient(DynamoDBClient);
 
@@ -22,6 +22,7 @@ const dynamodbItem = {
   [UserFields.create_timestamp]: { S: dte },
   [UserFields.update_timestamp]: { S: dte },
 };
+const TableName = DynamoDbConstruct.getTableName(TableBaseNames.USERS);
 
 const testPut = () => {  
   describe('Dao user create', () => {    
@@ -93,7 +94,7 @@ const testPut = () => {
       const expectedResponse = {
         ConsumedCapacity: {
           CapacityUnits: 1,
-          TableName: DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME
+          TableName
         }
       };
       dbMockClient.on(PutItemCommand).resolves(expectedResponse);
@@ -125,7 +126,7 @@ const testPut = () => {
       const expectedResponse = {
         ConsumedCapacity: {
           CapacityUnits: 1,
-          TableName: DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME
+          TableName
         }
       };
       dbMockClient.on(PutItemCommand).resolves(expectedResponse);
@@ -257,7 +258,7 @@ const testDelete = () => {
       dbMockClient.on(DeleteItemCommand).resolves({      
         ConsumedCapacity: {
           CapacityUnits: 1,
-          TableName: DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME
+          TableName
         }      
       });
       const dao = DAOFactory.getInstance({
@@ -274,7 +275,7 @@ const testDelete = () => {
       dbMockClient.on(DeleteItemCommand).resolves({      
         ConsumedCapacity: {
           CapacityUnits: 1,
-          TableName: DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME
+          TableName
         }      
       });
       const dao = DAOFactory.getInstance({
@@ -303,7 +304,7 @@ const testDeleteEntity = () => {
   const response = {      
     ConsumedCapacity: {
       CapacityUnits: 1,
-      TableName: DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME
+      TableName
     }      
   };
   dbMockClient.on(DeleteItemCommand).resolves(response);

--- a/lib/lambda/_lib/dao/db-update-builder.consenter.test.ts
+++ b/lib/lambda/_lib/dao/db-update-builder.consenter.test.ts
@@ -1,5 +1,5 @@
 import { UpdateItemCommandInput } from '@aws-sdk/client-dynamodb';
-import { DynamoDbConstruct } from '../../../DynamoDb';
+import { DynamoDbConstruct, TableBaseNames } from '../../../DynamoDb';
 import { consenterUpdate } from './db-update-builder.consenter';
 import { Affiliate, Consenter, ConsenterFields } from './entity';
 
@@ -9,7 +9,9 @@ describe('getCommandInputBuilderForConsenterUpdate', () => {
 
   const isoString = new Date().toISOString();
   Date.prototype.toISOString = () => { return isoString; };
-  const TableName = DynamoDbConstruct.DYNAMODB_CONSENTER_TABLE_NAME;
+  const { getTableName } = DynamoDbConstruct;
+  const { CONSENTERS } = TableBaseNames;
+  const TableName = getTableName(CONSENTERS);
   const daffyEmail = 'daffyduck@warnerbros.com';
 
   const oldConsenter = {

--- a/lib/lambda/functions/authorized-individual/AuthorizedIndividual.test.ts
+++ b/lib/lambda/functions/authorized-individual/AuthorizedIndividual.test.ts
@@ -3,7 +3,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { Roles, User } from '../../_lib/dao/entity';
 import { entity, bugsbunny, daffyduck, yosemitesam } from './MockObjects';
-import * as mockCommandInput from './DemolitionCommandInputMock.json';
+import { expectedCommandInput } from './DemolitionCommandInputMock';
 import { Task, handler } from './AuthorizedIndividual';
 import { LambdaProxyIntegrationResponse } from '../Utils';
 import { AbstractRoleApi, IncomingPayload, OutgoingBody } from '../../../role/AbstractRole';
@@ -11,7 +11,7 @@ import { DAOUser, FactoryParms } from '../../_lib/dao/dao';
 
 const deletedUsers = [ bugsbunny, daffyduck, yosemitesam ] as User[];
 const dryRun = false;
-const demolish = async ():Promise<any> => mockCommandInput;
+const demolish = async ():Promise<any> => expectedCommandInput;
 
 enum Scenario { NORMAL, UNMATCHABLE_ENTITY, NON_EMAILS };
 let currentScenario = Scenario.NORMAL as Scenario;
@@ -62,6 +62,8 @@ jest.mock('../../_lib/dao/dao.ts', () => {
           case 'invitation':
             return null;
           case 'consenter':
+            return null;
+          case 'config':
             return null;
         }
       })

--- a/lib/lambda/functions/authorized-individual/Demolition.test.ts
+++ b/lib/lambda/functions/authorized-individual/Demolition.test.ts
@@ -2,10 +2,10 @@ import { AdminDeleteUserCommand, CognitoIdentityProviderClient } from '@aws-sdk/
 import { DynamoDBClient, TransactWriteItemsCommand } from '@aws-sdk/client-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
-import { DAOConsenter, DAOEntity, DAOInvitation, DAOUser, FactoryParms } from '../../_lib/dao/dao';
-import { Consenter, Invitation, User } from '../../_lib/dao/entity';
+import { DAOConfig, DAOConsenter, DAOEntity, DAOInvitation, DAOUser, FactoryParms } from '../../_lib/dao/dao';
+import { Config, Consenter, Invitation, User } from '../../_lib/dao/entity';
 import { EntityToDemolish } from './Demolition';
-import * as expectedCommandInput from './DemolitionCommandInputMock.json';
+import { expectedCommandInput } from './DemolitionCommandInputMock';
 import { entity, bugsbunny, daffyduck, yosemitesam, bugbunny_invitation, daffyduck_invitation, yosemitesam_invitation } from './MockObjects';
 
 const dbMockClient = mockClient(DynamoDBClient);
@@ -36,6 +36,12 @@ const mockConsenterRead = jest.fn(async ():Promise<any> => {
   });
 }) as any;
 
+const mockConfigRead = jest.fn(async ():Promise<any> => {
+  return new Promise((resolve) => {
+    resolve({ } as Config[])
+  })
+}) as any;
+
 jest.mock('../../_lib/dao/dao.ts', () => {
   return {
     __esModule: true,
@@ -50,6 +56,8 @@ jest.mock('../../_lib/dao/dao.ts', () => {
             return { read: mockEntityRead } as DAOEntity;
           case 'consenter':
             return { read: mockConsenterRead } as DAOConsenter;
+          case 'config':
+            return { read: mockConfigRead } as DAOConfig;
         }
       })
     }

--- a/lib/lambda/functions/authorized-individual/DemolitionCommandInputMock.ts
+++ b/lib/lambda/functions/authorized-individual/DemolitionCommandInputMock.ts
@@ -1,8 +1,13 @@
-{
+import { DynamoDbConstruct, TableBaseNames } from "../../../DynamoDb"
+
+const { getTableName } = DynamoDbConstruct;
+const { ENTITIES, USERS, INVITATIONS } = TableBaseNames;
+
+export const expectedCommandInput = {
   "TransactItems": [
     {
       "Delete": {
-        "TableName": "ett-users",
+        "TableName": `${getTableName(USERS)}`,
         "Key": {
           "entity_id": {
             "S": "mock_entity_id"
@@ -15,7 +20,7 @@
     },
     {
       "Delete": {
-        "TableName": "ett-users",
+        "TableName": `${getTableName(USERS)}`,
         "Key": {
           "entity_id": {
             "S": "mock_entity_id"
@@ -28,7 +33,7 @@
     },
     {
       "Delete": {
-        "TableName": "ett-users",
+        "TableName": `${getTableName(USERS)}`,
         "Key": {
           "entity_id": {
             "S": "mock_entity_id"
@@ -41,7 +46,7 @@
     },
     {
       "Delete": {
-        "TableName": "ett-invitation",
+        "TableName": `${getTableName(INVITATIONS)}`,
         "Key": {
           "code": {
             "S": "abc123"
@@ -51,7 +56,7 @@
     },
     {
       "Delete": {
-        "TableName": "ett-invitation",
+        "TableName": `${getTableName(INVITATIONS)}`,
         "Key": {
           "code": {
             "S": "def456"
@@ -61,7 +66,7 @@
     },
     {
       "Delete": {
-        "TableName": "ett-invitation",
+        "TableName": `${getTableName(INVITATIONS)}`,
         "Key": {
           "code": {
             "S": "ghi789"
@@ -71,7 +76,7 @@
     },
     {
       "Delete": {
-        "TableName": "ett-entities",
+        "TableName": `${getTableName(ENTITIES)}`,
         "Key": {
           "entity_id": {
             "S": "mock_entity_id"

--- a/lib/lambda/functions/cognito/PreSignup.test.ts
+++ b/lib/lambda/functions/cognito/PreSignup.test.ts
@@ -1,4 +1,5 @@
-import { Invitation, Role, Roles } from '../../_lib/dao/entity';
+import { DAOConsenter, ReadParms } from '../../_lib/dao/dao';
+import { Consenter, Invitation, Role, Roles } from '../../_lib/dao/entity';
 import { Messages, handler } from './PreSignup';
 import * as event from './PreSignupEventMock.json'
 
@@ -29,6 +30,21 @@ jest.mock('../../_lib/cognito/Lookup.ts', () => {
     ...originalModule,
     lookupRole: async (userPoolId:string, clientId:string, region:string):Promise<Role|undefined> => {
       return role;
+    }
+  }
+});
+
+jest.mock('../../_lib/dao/dao-consenter.ts', () => {
+  const originalModule = jest.requireActual('../../_lib/dao/dao-consenter');
+  return {
+    __esModule: true,
+    ...originalModule,
+    ConsenterCrud: (consenterInfo:Consenter, _dryRun:boolean=false): DAOConsenter => {
+      return {
+        read: async (readParms?:ReadParms):Promise<(Consenter|null)|Consenter[]> => {
+          return { email: consenterInfo.email } as Consenter
+        }
+      } as DAOConsenter
     }
   }
 });

--- a/lib/lambda/functions/consenting-person/ConsentingPerson.test.ts
+++ b/lib/lambda/functions/consenting-person/ConsentingPerson.test.ts
@@ -28,7 +28,7 @@ describe('Consenting Person lambda trigger: handler', () => {
   });
 });
 
-describe('Consenting Person lambda trigger: send-affiliate-data', () => {
+describe(`Consenting Person lambda trigger: ${Task.SEND_AFFILIATE_DATA}`, () => {
   const task = Task.SEND_AFFILIATE_DATA;
   it('Should return invalid response if exhibit data is missing', async () => {
     await SendAffiliateData.missingExhibitData(handler, mockEvent, task, msgs.missingExhibitData); 
@@ -41,6 +41,15 @@ describe('Consenting Person lambda trigger: send-affiliate-data', () => {
   });
   it('Should return invalid response if email of exhibit issuer is missing', async () => {
     await SendAffiliateData.missingEmail(handler, mockEvent, task, msgs.missingExhibitFormIssuerEmail); 
+  });
+  it('Should return invalid response if exhibit issuer has not consented', async () => {
+    await SendAffiliateData.missingConsent(handler, mockEvent, task, msgs.missingConsent)
+  });
+  it('Should return invalid response if exhibit issuer has retracted their consent', async () => {
+    await SendAffiliateData.rescindedConsent(handler, mockEvent, task, msgs.missingConsent)
+  });
+  it('Should return invalid response if exhibit issuer has consented, but is inactive', async () => {
+    await SendAffiliateData.consenterInactive(handler, mockEvent, task, msgs.missingConsent)
   });
   it('Should behave as expected if error is encountered looking up the entity', async () => {
     await SendAffiliateData.entityLookupFailure(handler, mockEvent, task);

--- a/lib/lambda/functions/consenting-person/ConsentingPerson.ts
+++ b/lib/lambda/functions/consenting-person/ConsentingPerson.ts
@@ -30,6 +30,7 @@ export const INVALID_RESPONSE_MESSAGES = {
   invalidAffiliateRecords: 'Affiliate item with missing/invalid value',
   missingEntityId: 'Missing entity_id!',
   missingConsent: 'Consent is required before the requested operation can be performed',
+  inactiveConsenter: 'Consenter is inactive',
   missingExhibitFormIssuerEmail: 'Missing email of exhibit form issuer!',
   emailFailure: 'Email failed for one or more recipients!'
 }
@@ -276,6 +277,9 @@ export const saveExhibitData = async (email:string, data:ExhibitFormData): Promi
   // Abort if the consenter has not yet consented
   const consenterInfo = await getConsenter(email, false) as ConsenterInfo;
   if( ! consenterInfo?.activeConsent) {
+    if(consenterInfo?.consenter?.active == YN.No) {
+      return invalidResponse(INVALID_RESPONSE_MESSAGES.inactiveConsenter);
+    }
     return invalidResponse(INVALID_RESPONSE_MESSAGES.missingConsent);
   }
 

--- a/lib/lambda/functions/injector-event/Injector.mjs
+++ b/lib/lambda/functions/injector-event/Injector.mjs
@@ -80,11 +80,11 @@ const hasPlaceholder = content => {
 //               "s3SchemaVersion": "1.0",
 //               "configurationId": "ZWYxNTAyNjgtZWU2ZS00MTllLWI1ODAtMjc4MDlmZWQ4MjU5",
 //               "bucket": {
-//                   "name": "ett-static-site-content",
+//                   "name": "ett-dev-static-site-content",
 //                   "ownerIdentity": {
 //                       "principalId": "A1MBV5VYEBF19X"
 //                   },
-//                   "arn": "arn:aws:s3:::ett-static-site-content"
+//                   "arn": "arn:aws:s3:::ett-dev-static-site-content"
 //               },
 //               "object": {
 //                   "key": "index.htm",

--- a/lib/lambda/functions/sys-admin/DynamoDbTableOutput.ts
+++ b/lib/lambda/functions/sys-admin/DynamoDbTableOutput.ts
@@ -2,9 +2,10 @@ import { AttributeValue, DynamoDBClient, ScanCommand, ScanInput, ScanOutput } fr
 import { View } from "./view/View";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { convertFromApiObject } from "../../_lib/dao/db-object-builder";
-import { DynamoDbConstruct } from "../../../DynamoDb";
+import { DynamoDbConstruct, TableBaseNames } from "../../../DynamoDb";
 import { HtmlTableView } from "./view/HtmlTableView";
 import { viewHtml } from "../Utils";
+import { TableBase } from "aws-cdk-lib/aws-dynamodb";
 
 /**
  * Output a "display" of the entire content of the specified dynamodb table that is based on the
@@ -53,13 +54,15 @@ const { argv:args } = process;
 
 if(args.length > 2 && args[2] == 'RUN_MANUALLY_DYNAMODB_DISPLAY') {
   const table = args[3];
+  const { getTableName } = DynamoDbConstruct;
+  const { USERS, ENTITIES, INVITATIONS, CONSENTERS } = TableBaseNames;
 
   let tableName;
   switch(table) {
-    case 'user': tableName = DynamoDbConstruct.DYNAMODB_USER_TABLE_NAME; break;
-    case 'entity': tableName = DynamoDbConstruct.DYNAMODB_ENTITY_TABLE_NAME; break;
-    case 'invitation': tableName = DynamoDbConstruct.DYNAMODB_INVITATION_EMAIL_INDEX; break;
-    case 'cp': tableName = DynamoDbConstruct.DYNAMODB_CONSENTER_TABLE_NAME; break;
+    case 'user': tableName = getTableName(USERS); break;
+    case 'entity': tableName = getTableName(ENTITIES); break;
+    case 'invitation': tableName = getTableName(INVITATIONS); break;
+    case 'cp': tableName = getTableName(CONSENTERS); break;
   }
 
   if( ! tableName) {

--- a/lib/lambda/functions/sys-admin/SysAdminUser.ts
+++ b/lib/lambda/functions/sys-admin/SysAdminUser.ts
@@ -109,14 +109,8 @@ export const getDbTable = async (parms:any):Promise<LambdaProxyIntegrationRespon
 
   console.log(`Getting database table: ${tableName}`);
 
-  const { 
-    DYNAMODB_CONSENTER_TABLE_NAME: consenters, 
-    DYNAMODB_ENTITY_TABLE_NAME: entities, 
-    DYNAMODB_INVITATION_TABLE_NAME: invitations, 
-    DYNAMODB_USER_TABLE_NAME: users
-  } = DynamoDbConstruct;
+  const tables:string[] = DynamoDbConstruct.getTableNames();
 
-  const tables = [ consenters, entities, invitations, users ];
   const noSuchTableMsg = `Bad Request - No matching table for: ${tableName}`;
   // Find a table that is equal to or ends with the provided value.
   tableName = tables.find(tb => tb == tableName || tb.endsWith(tableName));
@@ -185,7 +179,7 @@ if(args.length > 3 && args[2] == 'RUN_MANUALLY_SYS_ADMIN') {
   const email = args[3];
   const landscape = args[4];
   
-  process.env.USERPOOL_NAME = 'ett-cognito-userpool'; 
+  process.env.USERPOOL_NAME = 'ett-dev-cognito-userpool'; 
   process.env.COGNITO_DOMAIN = 'ett-dev.auth.us-east-2.amazoncognito.com'; //  `${this.context.STACK_ID}-${this.context.TAGS.Landscape}.${REGION}.amazoncognito.com`
   process.env.REGION = 'us-east-2';
   process.env.DEBUG = 'true';

--- a/lib/role/AbstractRole.ts
+++ b/lib/role/AbstractRole.ts
@@ -90,14 +90,14 @@ export class AbstractRoleApi extends Construct {
 
     // Create a log group for the api gateway to log to.
     const log_group = new LogGroup(this, `RestApiLogGroup`, {
-      logGroupName: `/aws/lambda/${constructId}RestApiLogGroup`,
+      logGroupName: `/aws/lambda/ett-${stageName}-${role}-rest-api-log-group`,
       removalPolicy: RemovalPolicy.DESTROY,
     });
 
     // Create the api gateway REST api.
     const api = new RestApi(this, `LambdaRestApi`, {
       description,
-      restApiName: `Ett-${role}-rest-api-${stageName}`,
+      restApiName: `ett-${stageName}-${role}-rest-api`,
       deployOptions: { 
         stageName,
         accessLogDestination: new LogGroupLogDestination(log_group),
@@ -125,7 +125,7 @@ export class AbstractRoleApi extends Construct {
 
     // Let the cognito user pool control access to the api. Add an api gateway authorizer of type "COGNITO_USER_POOLS"
     const authorizer = new CognitoUserPoolsAuthorizer(this, 'UserPoolAuthorizer', {
-      authorizerName: `${constructId}-authorizer`,
+      authorizerName: `ett-${stageName}-${constructId}-authorizer`,
       cognitoUserPools: [ userPool ],
       identitySource: 'method.request.header.Authorization',
     });
@@ -146,7 +146,7 @@ export class AbstractRoleApi extends Construct {
     // validity based on token expiration, and access level based on the scopes in token claims
     const resourceServer = userPool.addResourceServer(`${constructId}ResourceServer`, {
       identifier: resourceServerId,
-      userPoolResourceServerName: `${resourceServerId}-resource-server`,
+      userPoolResourceServerName: `ett-${stageName}-${resourceServerId}-resource-server`,
       scopes
     });
 

--- a/lib/role/AuthorizedIndividual.ts
+++ b/lib/role/AuthorizedIndividual.ts
@@ -58,14 +58,14 @@ export class AuthorizedIndividualApi extends AbstractRole {
 export class LambdaFunction extends AbstractFunction {
   constructor(scope: Construct, constructId: string, parms:ApiConstructParms) {
     const context:IContext = scope.node.getContext('stack-parms');
-    const { userPool } = parms;
+    const { userPool, landscape } = parms;
     const { userPoolId, userPoolArn } = userPool;
     super(scope, constructId, {
       runtime: Runtime.NODEJS_18_X,
       memorySize: 1024,
       entry: 'lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts',
       // handler: 'handler',
-      functionName: `Ett${constructId}`,
+      functionName: `ett-${landscape}-${Roles.RE_AUTH_IND}-user`,
       description: 'Function for all authorized individual activity.',
       cleanup: true,
       bundling: {

--- a/lib/role/ConsentingPerson.ts
+++ b/lib/role/ConsentingPerson.ts
@@ -57,14 +57,14 @@ export class ConsentingPersonApi extends AbstractRole {
 export class LambdaFunction extends AbstractFunction {
   constructor(scope: Construct, constructId: string, parms:ApiConstructParms) {
     const context:IContext = scope.node.getContext('stack-parms');
-    const { userPool, cloudfrontDomain } = parms;
+    const { userPool, cloudfrontDomain, landscape } = parms;
     const { userPoolArn, userPoolId } = userPool;
     super(scope, constructId, {
       runtime: Runtime.NODEJS_18_X,
       memorySize: 1024,
       entry: 'lib/lambda/functions/consenting-person/ConsentingPerson.ts',
       // handler: 'handler',
-      functionName: `Ett${constructId}`,
+      functionName: `ett-${landscape}-${Roles.CONSENTING_PERSON}-user`,
       description: 'Function for all consenting persons activity.',
       cleanup: true,
       bundling: {

--- a/lib/role/HelloWorld.ts
+++ b/lib/role/HelloWorld.ts
@@ -6,10 +6,12 @@ import { AbstractRole, AbstractRoleApi } from "./AbstractRole";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { RemovalPolicy } from "aws-cdk-lib";
 import { Roles } from  '../lambda/_lib/dao/entity';
+import { IContext } from "../../contexts/IContext";
 
 export interface HelloWorldParms {
   userPool: UserPool, 
-  cloudfrontDomain: string
+  cloudfrontDomain: string,
+  landscape: string
 }
 
 export class HelloWorldApi extends AbstractRole {
@@ -20,12 +22,13 @@ export class HelloWorldApi extends AbstractRole {
 
     super(scope, constructId);
 
-    const { userPool, cloudfrontDomain } = parms;
+    const { userPool, cloudfrontDomain, landscape } = parms;
+    const functionName = `ett-${landscape}-${Roles.HELLO_WORLD}-user`;
 
     const lambdaFunction = new Function(scope, `${constructId}Lambda`, {
       runtime: Runtime.NODEJS_18_X,
       handler: 'index.handler',
-      functionName: `Ett${constructId}Lambda`,
+      functionName,
       description: 'Just a simple lambda for testing cognito authorization',
       code: Code.fromInline(`
       exports.handler = async (event) => {
@@ -50,7 +53,7 @@ export class HelloWorldApi extends AbstractRole {
     )});
 
     const log_group = new LogGroup(this, `${constructId}LogGroup`, {
-      logGroupName: `/aws/lambda/${constructId}Lambda`,
+      logGroupName: `/aws/lambda/${functionName}`,
       removalPolicy: RemovalPolicy.DESTROY,
     });
 

--- a/lib/role/ReAdmin.ts
+++ b/lib/role/ReAdmin.ts
@@ -11,6 +11,7 @@ import { Configurations } from "../lambda/_lib/config/Config";
 export interface AdminUserParms {
   userPool: UserPool, 
   cloudfrontDomain: string,
+  landscape: string,
 }
 
 export class ReAdminUserApi extends AbstractRole {
@@ -61,14 +62,14 @@ export class ReAdminUserApi extends AbstractRole {
 export class LambdaFunction extends AbstractFunction {
   constructor(scope:Construct, constructId:string, parms:AdminUserParms) {
     const context:IContext = scope.node.getContext('stack-parms');
-    const { userPool, cloudfrontDomain } = parms;
+    const { userPool, cloudfrontDomain, landscape } = parms;
     const { userPoolArn, userPoolId } = userPool;
     
     super(scope, constructId, {
       runtime: Runtime.NODEJS_18_X,
       entry: 'lib/lambda/functions/re-admin/ReAdminUser.ts',
       // handler: 'handler',
-      functionName: `Ett${constructId}`,
+      functionName: `ett-${landscape}-${Roles.RE_ADMIN}-user`,
       memorySize: 1024,
       description: 'Function for all re admin user activity.',
       cleanup: true,

--- a/lib/role/SysAdmin.ts
+++ b/lib/role/SysAdmin.ts
@@ -58,7 +58,7 @@ export class SysAdminApi extends AbstractRole {
 export class LambdaFunction extends AbstractFunction {
   constructor(scope: Construct, constructId: string, parms:ApiConstructParms) {
     const context:IContext = scope.node.getContext('stack-parms');
-    const { CONFIG, REGION } = context;
+    const { CONFIG, REGION, TAGS: { Landscape:landscape } } = context;
     const config = new Configurations(CONFIG);
     const { userPool, userPoolName, userPoolDomain, cloudfrontDomain, redirectPath } = parms;
     const { userPoolArn } = userPool;
@@ -69,7 +69,7 @@ export class LambdaFunction extends AbstractFunction {
       memorySize: 1024,
       entry: 'lib/lambda/functions/sys-admin/SysAdminUser.ts',
       // handler: 'handler',
-      functionName: `Ett${constructId}`,
+      functionName: `ett-${landscape}-${Roles.SYS_ADMIN}-user`,
       description: 'Function for all sys admin user activity.',
       cleanup: true,
       bundling: {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "redeploy": "cdk destroy -f && npm run deploy",
     "synth": "cdk synth 2>&1 | tee cdk.out/ett.template.yaml",
     "clearcache": "sh bin/clearcache.sh",
-    "publish": "sh -c 'aws s3 cp ./frontend/index.htm s3://ett-static-site-content/'"
+    "publish": "sh bin/publish.sh"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.352.0",


### PR DESCRIPTION
This feature makes the necessary name changes to resources _(ie: dynamodb tables, log groups, lambda function names, etc)_ to prevent collisions if more than one stack is created in the same account and region.
This is done by making these names also reflect the landscape.