### PR TITLE
Adding in "Blank sheet of paper" feature for sysadmin

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,8 +33,7 @@
       "args": [
         "${workspaceFolder}/lib/lambda/functions/sys-admin/SysAdminUser.ts",
         "RUN_MANUALLY_SYS_ADMIN",
-        "sysadmin1@warhen.work",
-        "dev"
+        "sysadmin1@warhen.work"
       ], 
       "env": {
         "AWS_PROFILE": "bu",

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -785,6 +785,9 @@
                 <li class="nav-item">
                   <a class="nav-link" id="sys-admin-db-tab" data-toggle="tab" href="#sys-admin-db" role="tab" aria-controls="sys-admin-db" aria-selected="false">Database</a>
                 </li>
+                <li class="nav-item"></li>
+                  <a class="nav-link" id="sys-clean-sheet-tab" data-toggle="tab" href="#sys-admin-clean-sheet" role="tab" aria-controls="sys-admin-clean-sheet" aria-selected="false">Clean Sheet of Paper</a>
+                </li>
               </ul>
               <div class="tab-content" id="sysAdminContent">
                 <div class="tab-pane fade show active" id="sys-admin-invitation" role="tabpanel" aria-labelledby="sys-admin-invitation-tab">
@@ -851,6 +854,29 @@
                       <div class="dbTableLabel">Consenters</div>
                       <button class="btn btn-primary btn" type="button" onclick="refreshDbTable('consenters')">Load/Refresh</button>
                       <div id="db-table-consenters" style="margin-top:10px;"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="tab-pane fade" id="sys-admin-clean-sheet" role="tabpanel" aria-labelledby="sys-admin-clean-sheet-tab">
+                  <h3 class="display-7 fw-bold" style="text-align:center; margin-bottom: 20px;">"Clean sheet of paper"</h3>
+                  <div style="overflow:auto;">
+                    <div style="float:left; clear:both; margin-bottom: 30px;">
+                      <p>
+                        This is a "nuclear option" for developers/testers to bring the state of the app back to "factory settings".<br>
+                        <span style="font-style: italic;">NOTE: Probably a good idea not to expose this tab in any production deployment</span>
+                      </p>
+                      <p>
+                        All accumulated records and activity will be wiped out so that one can begin from scratch.<br>
+                        Among the items wiped out are:<br>
+                        <ul>
+                          <li><b>Dynamodb:</b> All records from every table <span style="font-style: italic;">(except sysadmins and configurations)</span></li>
+                          <li><b>Cognito:</b> All records for every user <span style="font-style: italic;">(except sysadmins)</span></li>
+                          <li><b>S3:</b> Everything</li>
+                        </ul>
+                      </p>
+                      <p>
+                        <button id="btnCleanSheet" class="btn btn-danger btn-lg">DETONATE <i class="bi bi-lightning-fill"></i></button>
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -1960,6 +1986,47 @@
         const { message, payload } = package;
         if(payload.ok) {
           alert('Entity terminated');
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
+    }
+
+    const cleanSheet = async () => {
+      if( ! confirm("Are you sure about this?\n\n" +
+      "Click 'Ok' to proceed,\n" +
+      "Click 'Cancel' to abort")) {
+        alert('Cancelled');
+        return;
+      }
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      try {
+        const role = AccessJwtCookie.getRole().name;
+        const outgoingPayload = {
+          task: 'clean-sheet',
+          parameters: {}
+        }
+
+        const response = await fetch(apiUri(role), {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify(outgoingPayload)
+          }
+        });
+
+        const package = await response.json();
+        const { message, payload } = package;
+        if(payload.ok) {
+          alert('Completed! You now have a clean sheet of paper');
         }
         else {
           msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
@@ -3505,6 +3572,9 @@
       document.getElementById('btnTerminateEntity').addEventListener('click', async () => {
         await terminateEntity(invitationCode);
       });
+      document.getElementById('btnCleanSheet').addEventListener('click', async () => {
+        await cleanSheet();
+      });
       document.getElementById('btnSendDisclosureRequest').addEventListener('click', async () => {
         await sendDisclosureRequest();
       });
@@ -3685,7 +3755,7 @@
               const { users=[], entity_name } = (entity ?? {});
               const validUsers = users.filter(u => { return u.active == 'Y'; });
               document.getElementById('app-section-RE_AUTH_IND').style.display = 'inline';
-              if(validUsers < 2) {
+              if(validUsers.length < 2) {
                 document.getElementById('authNotReady').style.display = 'inline';
                 if(entity_name) {
                   document.getElementById('disclosureRequestEntityName').innerText = entity_name;

--- a/lib/lambda/_lib/BlankSheetOfPaper.ts
+++ b/lib/lambda/_lib/BlankSheetOfPaper.ts
@@ -1,40 +1,85 @@
-import { marshall } from "@aws-sdk/util-dynamodb";
-import { EntityToDemolish } from "../functions/authorized-individual/Demolition";
-import { lookupUserPoolId } from "./cognito/Lookup";
-import { ConsenterCrud } from "./dao/dao-consenter";
-import { ENTITY_WAITING_ROOM, EntityCrud } from "./dao/dao-entity";
-import { Consenter, Entity, YN } from "./dao/entity";
-import { DynamoDBClient, TransactWriteItem, TransactWriteItemsCommand, TransactWriteItemsCommandInput } from "@aws-sdk/client-dynamodb";
-import { DynamoDbConstruct, TableBaseNames } from "../../DynamoDb";
 import { AdminDeleteUserCommand, AdminDeleteUserCommandOutput, AdminDeleteUserRequest, CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
+import { AttributeValue } from "@aws-sdk/client-dynamodb";
+import { IContext } from "../../../contexts/IContext";
+import { DynamoDbConstruct, TableBaseNames } from "../../DynamoDb";
+import { EntityToDemolish } from "../functions/authorized-individual/Demolition";
+import { ExhibitFormsBucketEnvironmentVariableName } from "../functions/consenting-person/BucketItemMetadata";
+import { lookupUserPoolId } from "./cognito/Lookup";
+import { ENTITY_WAITING_ROOM, EntityCrud } from "./dao/dao-entity";
+import { ConsenterFields, Entity, YN } from "./dao/entity";
+import { BucketToEmpty, DynamoDbTableToEmpty } from "./Emptier";
 
 /**
  * --------------------------------------------------------
  *    Return the system state to a "Blank sheet of paper"
  * --------------------------------------------------------
  * Remove any trace of content related to all entities, except for the ENTITY_WAITING_ROOM.
- * This will leave only two entries left to the database: 
+ * This will leave only three kinds of entries left to the database: 
  *   1) The ENTITY_WAITING_ROOM entities table item.
  *   2) The SysAdmin users table item(s).
+ *   3) The Configuration table items.
  * This will leave only one userpool item remaining:
  *   1) The SysAdmin item (or items if more than one SysAdmin)
  * @param dryRun 
  */
-const wipeClean = async (dryRun=true) => {
+export const wipeClean = async (dryRun=true) => {
 
+  /**
+   * Query for a list of active or non-active consenters and delete each corresponding consenter item.
+   * @param active 
+   */
+  const deleteConsenters = async (dryRun:boolean):Promise<any> => {
+    const { getTableName } = DynamoDbConstruct;
+    const { CONSENTERS } = TableBaseNames
+    const  TableName = getTableName(CONSENTERS);
+    const tableToEmpty = new DynamoDbTableToEmpty({
+      TableName,
+      partitionKey: ConsenterFields.email,
+      region: REGION,
+      dryRun
+    });
+
+    const deletions = await tableToEmpty.empty('email, sub') as Record<string, AttributeValue>[];
+
+    if( ! deletions || deletions.length == 0) {
+      console.log(`No consenters to delete`);
+      return;
+    }
+
+    // Now remove the same consenters from the userpool
+    const cognitoClient = new CognitoIdentityProviderClient({ region: REGION });
+    for(let i=0; i<deletions.length; i++) {
+      try {
+        const { sub: { S:Username }, email: { S:email }} = deletions[i];
+        const input = { UserPoolId, Username } as AdminDeleteUserRequest;
+        const command = new AdminDeleteUserCommand(input);
+        console.log(`${dryRun ? 'DRYRUN: ' : '' }Removing consenter from userpool: ${JSON.stringify(input, null, 2)}`);
+        if(dryRun) {
+          return new Promise((resolve) => resolve('dryrun'));
+        }
+        const output = await cognitoClient.send(command) as AdminDeleteUserCommandOutput;
+        console.log(`User ${email} deleted: ${JSON.stringify(output, null, 2)}`);
+      }
+      catch(reason) {
+        console.log(JSON.stringify(reason, Object.getOwnPropertyNames(reason), 2));
+      }
+    }
+  }
+
+  
   // 1) Get environment variables
-  const { REGION, LANDSCAPE } = process.env;
+  const { PREFIX, REGION } = process.env;
+  if( ! PREFIX) {
+    console.log('PREFIX environment variable missing!');
+    return;
+  }
   if( ! REGION) {
     console.log('REGION environment variable missing!');
     return;
   }
-  if( ! LANDSCAPE) {
-    console.log('LANDSCAPE environment variable missing!');
-    return;
-  }
 
   // 2) Get the userpool ID
-  const UserPoolId = await lookupUserPoolId(`ett-${LANDSCAPE}-cognito-userpool`, REGION);
+  const UserPoolId = await lookupUserPoolId(`${PREFIX}-cognito-userpool`, REGION);
   process.env.USERPOOL_ID = UserPoolId;
 
   // 3) Get a list of all entities
@@ -42,82 +87,52 @@ const wipeClean = async (dryRun=true) => {
   const entities = await entityDao.read() as Entity[];
 
   // 4) Iterate over the entities and "demolish" each
+  let deletedEntities:number = 0
   for(let i=0; i<entities.length; i++) {
     const { entity_id } = entities[i];
     if(entity_id != ENTITY_WAITING_ROOM) {
       const entityToDemolish = new EntityToDemolish(entities[i].entity_id);
       entityToDemolish.dryRun = dryRun
       await entityToDemolish.demolish();
+      deletedEntities += 1;
     }
   }
+  console.log(`${deletedEntities} entities deleted`);
 
-  /**
-   * Query for a list of active or non-active consenters and delete each corresponding consenter item.
-   * @param active 
-   */
-  const deleteConsenters = async (active:YN):Promise<any> => {
-    const { getTableName } = DynamoDbConstruct;
-    const { CONSENTERS } = TableBaseNames
-    const  TableName = getTableName(CONSENTERS);
-    const TransactItems = [] as TransactWriteItem[];
-    const consentersToDelete = [] as Consenter[];
+  // 5) Remove all consenters from dynamodb and cognito
+  await deleteConsenters(dryRun);
 
-    // Build items into a transaction for deletion.
-    let consenterDao = ConsenterCrud({ active } as Consenter);
-    let consenters = await consenterDao.read() as Consenter[];
-    consenters.forEach(consenter => {
-      const { email, sub } = consenter;
-      const Key = marshall({ email, sub } as Consenter);
-      TransactItems.push({ Delete: { TableName, Key }} as TransactWriteItem);
-      consentersToDelete.push(consenter);
-    });
-
-    // Execute the transaction to delete the consenters
-    if(TransactItems.length > 0) {
-      const dynamodbCommandInput = { TransactItems } as TransactWriteItemsCommandInput;
-      console.log(`Deleting consenters: ${JSON.stringify(dynamodbCommandInput, null, 2)}`);
-      const transCommand = new TransactWriteItemsCommand(dynamodbCommandInput);
-      if(dryRun) {
-        return new Promise((resolve) => resolve('dryrun'));
-      }
-      const dbclient = new DynamoDBClient({ region: REGION });
-      await dbclient.send(transCommand);
-
-      // Now remove the same consenters from the userpool
-      const cognitoClient = new CognitoIdentityProviderClient({ region: REGION });
-      for(let i=0; i<consentersToDelete.length; i++) {
-        try {
-          const { sub:Username, email } = consentersToDelete[i];
-          const input = { UserPoolId, Username } as AdminDeleteUserRequest;
-          const command = new AdminDeleteUserCommand(input);
-          console.log(`Removing consenter from userpool: ${JSON.stringify(input, null, 2)}`);
-          if(dryRun) {
-            return new Promise((resolve) => resolve('dryrun'));
-          }
-          const output = await cognitoClient.send(command) as AdminDeleteUserCommandOutput;
-          console.log(`User ${email} deleted: ${JSON.stringify(output, null, 2)}`);
-        }
-        catch(reason) {
-          console.log(JSON.stringify(reason, Object.getOwnPropertyNames(reason), 2));
-        }
-      }
-    }
+  // 6) Empty out the exhibit forms bucket
+  const bucketName = process.env[ExhibitFormsBucketEnvironmentVariableName];
+  if( ! bucketName) {
+    console.error('Cannot empty exhibit forms s3 bucket! - bucket name unknown');
+    return;
   }
-
-  await deleteConsenters(YN.Yes);
-  await deleteConsenters(YN.No);
+  await (new BucketToEmpty(bucketName)).empty(dryRun);
 }
 
 const { argv:args } = process;
 if(args.length > 2 && args[2] == 'RUN_MANUALLY_BLANK_SHEET_OF_PAPER') {
-  process.env.DEBUG = 'true';
 
-  wipeClean(false)
-    .then(() => {
-      console.log('Entity deleted');
-    })
-    .catch((reason) => {
-      console.error(reason);
-    });
+  (async () => {
+    try {
+      process.env.DEBUG = 'true';
+      const context:IContext = await require('../../../contexts/context.json');
+      const { STACK_ID, REGION, TAGS: { Landscape } } = context;
+      const prefix = `${STACK_ID}-${Landscape}`;
+      const bucketName = `${prefix}-exhibit-forms`;
+      process.env[ExhibitFormsBucketEnvironmentVariableName] = bucketName;
+      process.env.PREFIX = prefix;
+      process.env.REGION = REGION;
+
+      const dryRun = false
+      await wipeClean(dryRun);
+
+      console.log('Clean sheet of paper!');
+    }
+    catch(e) {
+      console.error(e);
+    }
+  })();
 }
 

--- a/lib/lambda/_lib/Emptier.ts
+++ b/lib/lambda/_lib/Emptier.ts
@@ -1,0 +1,150 @@
+import { AttributeValue, BatchWriteItemCommand, BatchWriteItemCommandInput, DynamoDBClient, ScanCommand, ScanCommandInput, ScanCommandOutput, WriteRequest } from "@aws-sdk/client-dynamodb";
+import { DeleteObjectsCommand, ListObjectsV2Command, ListObjectsV2CommandOutput, S3Client } from "@aws-sdk/client-s3";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+
+/**
+ * Simple s3 bucket emptier. Run against any bucket with non-versioned content.
+ */
+export class BucketToEmpty {
+  private Bucket:string;
+  private region?:string;
+
+  constructor(bucket:string, region?:string) {
+    this.Bucket = bucket;
+    if(region) {
+      this.region = region;
+    }
+    this.region = process.env.REGION ?? process.env.AWS_REGION;
+  }
+
+  public empty = async (dryRun:boolean=true) => {
+    const { Bucket, region } = this;
+    if( ! region) {
+      console.error(`Cannot empty ${Bucket} - Region is not specified!`);
+    }
+    let total:number = 0;
+    let isTruncated = true;
+    let ContinuationToken: string | undefined = undefined;
+    const s3Client = new S3Client({ region });  // Replace with your bucket's region
+
+    while(isTruncated) {
+      // List objects in the bucket
+      const listObjectsResponse = await s3Client.send(new ListObjectsV2Command({
+        Bucket, ContinuationToken,
+      })) as ListObjectsV2CommandOutput;
+      
+      // Create an array of just object keys to delete
+      const objectsToDelete = listObjectsResponse.Contents?.map(object => ({
+        Key: object.Key,
+      }));
+
+      if (objectsToDelete && objectsToDelete.length > 0) {
+        if(dryRun) {
+          console.log(`DRYRUN: Deleting ${JSON.stringify(objectsToDelete, null, 2)} from ${Bucket}`);
+        }
+        else {
+          // Delete the objects in batches
+          await s3Client.send(new DeleteObjectsCommand({
+            Bucket, Delete: { Objects: objectsToDelete },
+          }));
+          console.log(`Deleted ${JSON.stringify(objectsToDelete, null, 2)} from ${Bucket}`);
+        }
+        total += objectsToDelete.length;
+      }
+      
+      // Check if more objects are left to list
+      isTruncated = listObjectsResponse.IsTruncated || false;
+      ContinuationToken = listObjectsResponse.NextContinuationToken;
+    }
+
+    console.log(`${dryRun ? 'DRYRUN: ' : '' }${total} objects deleted from ${Bucket}`);
+  }
+}
+
+export type EmptyDynamoDbTableParms = {
+  TableName:string, partitionKey:string, sortKey?:string, dryRun?:boolean, region?:string
+}
+
+/**
+ * Simple dynamodb table emptier.
+ */
+export class DynamoDbTableToEmpty {
+  private parms:EmptyDynamoDbTableParms;
+
+  constructor(parms:EmptyDynamoDbTableParms) {
+    if( ! parms.region) {
+      parms.region = (process.env.REGION ?? process.env.AWS_REGION);
+    }
+    if( ! parms.region) {
+      throw new Error('Region missing!');
+    }
+    this.parms = parms;
+  }
+
+  /**
+   * Empty an entire dynamodb table
+   * @param ProjectionExpression If not specified, the initial scan will return all fields of every item.
+   * @returns 
+   */
+  public empty = async (projectionExpression?:string):Promise<Record<string, AttributeValue>[]> => {
+    const { TableName, partitionKey, sortKey, region, dryRun } = this.parms;
+    const { getAliasedProjectionExpression, getExpressionAttributeNames } = this;
+    const client = new DynamoDBClient({ region });
+    const docClient = DynamoDBDocumentClient.from(client);
+    const deletedItems = [] as Record<string, AttributeValue>[];
+    let lastEvaluatedKey = undefined;
+    do {
+      // 1) Scan the table to retrieve all items
+      const scanParams = { TableName, ExclusiveStartKey: lastEvaluatedKey } as ScanCommandInput;
+      if(projectionExpression) {
+        scanParams.ExpressionAttributeNames = getExpressionAttributeNames(projectionExpression);
+        scanParams.ProjectionExpression = getAliasedProjectionExpression(projectionExpression);
+      }
+      const scanResult = await docClient.send(new ScanCommand(scanParams)) as ScanCommandOutput;
+      const items = scanResult.Items || [];
+      lastEvaluatedKey = scanResult.LastEvaluatedKey;
+
+      // 2) Batch delete items (up to 25 at a time)
+      while (items.length > 0) {
+        const batch = items.splice(0, 25);
+        deletedItems.push(...batch);
+        const deleteRequests = batch.map(item => {
+          const Key = { [partitionKey]: item[partitionKey] };
+          if(sortKey) {
+            Key[sortKey] = item[sortKey];
+          }
+          return { DeleteRequest: { Key } } as WriteRequest;
+        });
+
+        const batchWriteParams = {
+          RequestItems: {
+            [TableName]: deleteRequests
+          }
+        } as BatchWriteItemCommandInput;
+
+        const msg = `Deleting: ${JSON.stringify(batchWriteParams, null, 2)}`;
+        if(dryRun) {
+          console.log(`DRYRUN: ${msg}`);
+          continue;
+        }
+        console.log(msg);
+        await docClient.send(new BatchWriteItemCommand(batchWriteParams));
+      }
+
+    } while (lastEvaluatedKey);
+
+    return deletedItems;
+  }
+
+  private getExpressionAttributeNames = (projectionExpression:string):Record<string, string> => {
+    const names = {} as Record<string, string>;
+    projectionExpression.split(',').forEach(fldname => {
+      names[`#${fldname.trim()}`] = fldname.trim();
+    });
+    return names;
+  }
+
+  private getAliasedProjectionExpression = (projectionExpression:string):string => {
+    return projectionExpression.split(',').map(fldname => `#${fldname.trim()}`).join(', ');
+  }
+}

--- a/lib/role/SysAdmin.ts
+++ b/lib/role/SysAdmin.ts
@@ -64,13 +64,14 @@ export class LambdaFunction extends AbstractFunction {
     const { userPool, userPoolName, userPoolDomain, cloudfrontDomain, redirectPath, exhibitFormsBucket } = parms;
     const { userPoolArn } = userPool;
     const redirectURI = `${cloudfrontDomain}/${redirectPath}`.replace('//', '/');
-    
+    const prefix = `${STACK_ID}-${landscape}`;
+
     super(scope, constructId, {
       runtime: Runtime.NODEJS_18_X,
       memorySize: 1024,
       entry: 'lib/lambda/functions/sys-admin/SysAdminUser.ts',
       // handler: 'handler',
-      functionName: `${STACK_ID}-${landscape}-${Roles.SYS_ADMIN}-user`,
+      functionName: `${prefix}-${Roles.SYS_ADMIN}-user`,
       description: 'Function for all sys admin user activity.',
       cleanup: true,
       bundling: {
@@ -106,11 +107,20 @@ export class LambdaFunction extends AbstractFunction {
                 effect: Effect.ALLOW
               })
             ]
-          })
-        }
+          }),
+          'EttAuthIndExhibitFormBucketPolicy': new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                actions: [ 's3:*' ],
+                resources: [ exhibitFormsBucket.bucketArn, `${exhibitFormsBucket.bucketArn}/*` ],
+                effect: Effect.ALLOW
+              })
+            ]
+          })        }
       }),
       environment: {
         REGION,
+        PREFIX: prefix,
         [Configurations.ENV_VAR_NAME]: config.getJson(),
         USERPOOL_NAME: userPoolName,
         COGNITO_DOMAIN: userPoolDomain,


### PR DESCRIPTION
This feature puts another tab on the sysadmin dashboard that allows them to wipe out everything from the following locations:

- Dynamodb: All records from every table (except sysadmins and configurations)
- Cognito: All records for every user (except sysadmins)
- S3: Everything

This would be used by developers and QA to aid in testing, which often involves repeated trials where back to scratch would be a common state to return to.