### PR TITLE
Exhibit form request

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -88,6 +88,20 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "SendExhibitFormRequest",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/functions/authorized-individual/ExhibitFormRequestEmail.ts",
+        "RUN_MANUALLY_SEND_EXHIBIT_FORM_REQUEST"
+      ], 
+      "env": {
+        "AWS_PROFILE": "bu"
+      }, 
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "BucketExhibitForms",
       "skipFiles": [ "<node_internals>/**" ],
       "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -933,6 +933,14 @@
             <!--                  RE_AUTH_IND                   -->
             <!---------------------------------------------------->
             <div id="app-section-RE_AUTH_IND" style="display:none;">
+              <ul class="nav nav-tabs" id="authInd" role="tablist">
+                <li class="nav-item">
+                  <a class="nav-link active" id="auth-request-exhibits-tab" data-toggle="tab" href="#auth-request-exhibits" role="tab" aria-controls="auth-request-exhibits-link" aria-selected="true">Request Exhibit Forms</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" id="auth-request-disclosures-tab" data-toggle="tab" href="#auth-request-disclosures" role="tab" aria-controls="auth-request-disclosures-link" aria-selected="true">Request Disclosure Forms</a>
+                </li>
+              </ul>
               <h3 class="display-7 fw-bold">Welcome <span id="RE_AUTH_IND_username"></span></h3>
               <h3 class="display-7 fw-bold">Authorized Individual</h3>
 
@@ -943,29 +951,48 @@
                   Please revisit later.
                 </p>
               </div>
-              <div id="disclosureRequest" style="margin-top: 40px;">
-                <table class="disclosureRequest" style="width:fit-content; margin: 0 auto;">
-                  <tr>
-                    <th colspan="3">Make a disclosure request<br><hr></th>
-                  </tr>
-                  <tr>
-                    <td style="text-align: right;">Consenting individual email</td>
-                    <td colspan="2">
-                      <input id="disclosureRequestConsenterEmail" type="text" class="form-control">
-                    </td>
-                  </tr>
-                  <tr>
-                    <td style="text-align: right;">Affiliate of the consenting individual email</td>
-                    <td>
-                      <input id="disclosureRequestAffiliateEmail" type="text" class="form-control">
-                    </td>
-                    <td>
-                      <button id="btnSendDisclosureRequest" class="btn btn-primary btn-lg" type="button">Send <i class="bi-send-check"></i></button>
-                    </td>
-                  </tr>
-                </table>
+
+              <div class="tab-content" id="authIndContent">
+                <div class="tab-pane fade show active" id="auth-request-exhibits" role="tabpanel" aria-labelledby="auth-request-exhibits-tab">
+                  <div id="exhibitsRequest" style="margin-top: 40px; overflow: auto;">
+                    <div style="width:400px; margin:10px; display:inline;">
+                      <button id="consentersDropdownButton" style="height:66px;" class="btn btn-dark btn-lg dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        Individuals who have registered consent with ETT:
+                      </button>
+                      <div id="consentersDropdownList" class="dropdown-menu" aria-labelledby="consentersDropdownButton">
+                      </div>
+                    </div>
+                    <button id="btnSendExhibitsRequest" style="display:inline;" class="btn btn-primary btn-lg" type="button">Send <i class="bi-send-check"></i></button>
+                  </div>
+                </div>
+                <div class="tab-pane fade" id="auth-request-disclosures" role="tabpanel" aria-labelledby="auth-request-disclosures-tab">
+                  <div id="disclosureRequest" style="margin-top: 40px;">
+                    <table class="disclosureRequest" style="width:fit-content; margin: 0 auto;">
+                      <tr>
+                        <th colspan="3">Make a disclosure request<br><hr></th>
+                      </tr>
+                      <tr>
+                        <td style="text-align: right;">Consenting individual email</td>
+                        <td colspan="2">
+                          <input id="disclosureRequestConsenterEmail" type="text" class="form-control">
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="text-align: right;">Affiliate of the consenting individual email</td>
+                        <td>
+                          <input id="disclosureRequestAffiliateEmail" type="text" class="form-control">
+                        </td>
+                        <td>
+                          <button id="btnSendDisclosureRequest" class="btn btn-primary btn-lg" type="button">Send <i class="bi-send-check"></i></button>
+                        </td>
+                      </tr>
+                    </table>
+                  </div>
+                </div>                
               </div>
             </div>
+
+
 
 
             <!---------------------------------------------------->
@@ -1557,6 +1584,8 @@
     let consenterInfo;
 
     let selectedEntity;
+
+    let selectedConsenter;
 
     const rdoRoles = document.getElementsByName('rdoRole');
     rdoRoles.forEach(rdoRole => {
@@ -3430,6 +3459,56 @@
     }
 
     /**
+     * Populate the picklist that is available for authorized individuals to select from when
+     * choosing a consenting individual to whom they want to prompt via email for exhibit forms.
+     */
+    const populateConsenters = async () => {
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      try {
+        const role = AccessJwtCookie.getRole().name;
+
+        const response = await fetch(apiUri(role), {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify({ 
+              task: 'get-consenter-list', 
+              parameters: { fragment: undefined } 
+            })
+          }
+        });
+
+        const package = await response.json();
+        const { message, payload } = package;
+        if(payload.ok) {
+          const lbx = document.getElementById('consentersDropdownList');
+          lbx.innerHTML = '';
+          payload.consenters.forEach(consenter => {
+            const { email, fullname } = consenter;
+            const a = document.createElement("a");
+            a.id = email;
+            a.name = email;
+            a.className = 'dropdown-item';
+            a.href = '#';
+            a.innerHTML = `<b>${fullname}</b>, <span style='font-style:italic;'>(${email})</span>`;
+            lbx.appendChild(a);
+          })
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
+    }
+
+
+    /**
      * This function serves as a utility object for processing JWTs received from cognito and the cookies they are stored in.
      */
     const JwtCookie = function(cookieName) {
@@ -3686,6 +3765,12 @@
         $(this).tab('show')
       });
 
+      // Add show/hide behavior to the RE_AUTH_IND tabstrip
+      $('#authInd a').on('click', function (e) {
+        e.preventDefault()
+        $(this).tab('show')
+      });
+
       // Add show/hide behavior to the CONSENTER tabstrip
       $('#consenter a').on('click', function (e) {
         e.preventDefault()
@@ -3705,7 +3790,18 @@
           populateExhibitForm();
           toggleHighlight(document.querySelector('#requestingEntityDropdown'));
         }
-      })
+      });
+
+      // Add behavior to selection activity on the consenter picklist for exhibit form requests
+      $('#consentersDropdownButton').on('hide.bs.dropdown', function () {
+        const a = event.srcElement.parentElement;
+        const button = document.getElementById('consentersDropdownButton');
+        if(a.tagName == 'A' && a.name && a.id) {
+          button.innerHTML = a.innerHTML;
+          selectedConsenter = a.name;
+        }
+      });
+
 
       if(selected_role == 'SYS_ADMIN') {
         await buildConfigurationsTable();
@@ -3796,10 +3892,25 @@
                 if(entity_name) {
                   document.getElementById('disclosureRequestEntityName').innerText = entity_name;
                 }
-                const divs = document.querySelectorAll(`#disclosureRequest table`).forEach(d => d.style.color = '#cccccc');
-                const inputs = document.querySelectorAll(`#disclosureRequest input`).forEach(i => i.disabled = true);
-                const buttons = document.querySelectorAll(`#disclosureRequest button`).forEach(b => b.disabled = true);
+                document.querySelectorAll(`#disclosureRequest table`).forEach(d => d.style.color = '#cccccc');
+                document.querySelectorAll(`#disclosureRequest input`).forEach(i => i.disabled = true);
+                document.querySelectorAll(`#disclosureRequest button`).forEach(b => b.disabled = true);
+                document.querySelectorAll(`#exhibitsRequest select`).forEach(i => i.disabled = true);
+                document.querySelectorAll(`#exhibitsRequest button`).forEach(b => b.disabled = true);
               }
+              const checkConsenterListing = async () => {
+                const exhibitsTabFocus = document.getElementById('auth-request-exhibits').className.includes('show');
+                if(exhibitsTabFocus) {
+                  const items = document.querySelectorAll('consentersDropdownList a');
+                  if( !items || items.length == 0) {
+                    await populateConsenters();
+                  }
+                }
+              }
+              await checkConsenterListing();
+              document.getElementById('auth-request-exhibits-tab').addEventListener('show.bs.tab', async event => {
+                await checkConsenterListing();
+              });
               break;
             
             case 'CONSENTING_PERSON':

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -2224,20 +2224,37 @@
           const { consenter, entities } = payload;
           const { active, consented_timestamp, renewed_timestamp, rescinded_timestamp, email } = consenter ?? {};
 
+          /** Get the most recent date from an array of iso formatted date strings */
+          const getMostRecent = (timestamps=[]) => {
+            if(timestamps.length == 0) {
+              return;
+            }
+            timestamps.sort((a, b) => {
+              const dateA = new Date(a);
+              const dateB = new Date(b);
+              return dateB.getTime() - dateA.getTime();
+            });
+            return timestamps[0];
+          }
+
           const lastAction = () => {
-            const consented = new ComparableDate(consented_timestamp);
-            const rescinded = new ComparableDate(rescinded_timestamp);
-            const renewed = new ComparableDate(renewed_timestamp);
+            const consented = getMostRecent(consented_timestamp);
+            const rescinded = getMostRecent(rescinded_timestamp);
+            const renewed = getMostRecent(renewed_timestamp);
+
+            const consentedDate = new ComparableDate(consented);
+            const rescindedDate = new ComparableDate(rescinded);
+            const renewedDate = new ComparableDate(renewed);
             if(active == 'N') {
               return 'deactivated';
             }
-            if(consented.after(rescinded) && consented.after(renewed)) {
+            if(consentedDate.after(rescindedDate) && consentedDate.after(renewedDate)) {
               return 'consented';
             }
-            if(renewed.after(consented) && renewed.after(rescinded)) {
+            if(renewedDate.after(consentedDate) && renewedDate.after(rescindedDate)) {
               return 'renewed';
             }
-            if(rescinded.after(consented) && rescinded.after(renewed)) {
+            if(rescindedDate.after(consentedDate) && rescindedDate.after(renewedDate)) {
               return 'rescinded';
             }
             return task == 'correct-consent' ? 'corrected' : 'none';
@@ -2263,7 +2280,7 @@
 
           // Show the buttons used to renew, rescind, or edit consent
           showPostConsentFields = (lastAction) => {
-            const timestamp = renewed_timestamp ?? consented_timestamp;
+            const timestamp = getMostRecent(renewed_timestamp) ?? getMostRecent(consented_timestamp);
             const consentMsg = `Consent ${lastAction} at: ${timestamp}`;
             const color = lastAction == 'rescinded' ? 'red' : 'green';
             show('consentRescind');
@@ -2591,7 +2608,7 @@
           email: "roger@warnerbros.com",
           phone_number: '+6174448888',
           active: 'Y',
-          consented_timestamp: "2024-07-05T17:16:31.352Z",
+          consented_timestamp: [ "2024-07-05T17:16:31.352Z" ],
           create_timestamp: "2024-07-05T16:24:56.068Z",
           exhibit_forms: [
             { entity_id: entityId1, affiliates: [ affiliate1, affiliate2, affiliate3 ] },

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -2318,6 +2318,7 @@
             show('consentSend');
             if(document.location.pathname == '/consenter/exhibits/index.htm') {
               show('consenter-exhibit-link');
+              populateExhibitFormSignoffFields();
               document.getElementById('waitForAI').style.display = 'none';
               document.getElementById('consenter-exhibit-link').click();
             }
@@ -2332,11 +2333,11 @@
           };
 
           // Hide all consent options
-          hideConsentFields = () => {
-            document.getElementById('consenter-exhibit-link').style.display = 'none';
-            document.getElementById('consentFieldSet').style.display = 'none';
-            document.getElementById('consentOptions').style.display = 'none';
-            fill('apiResponse', `${email} found to be deactivated`);
+          hidePostConsentFields = () => {
+            hide('consenter-exhibit-link');
+            hide('consentOptions');
+            hide('consentFieldSet');
+            fill('apiResponse', `${email} found to be deactivated (has not yet submitted consent)`);
           }
 
           let _lastAction = lastAction();
@@ -2361,7 +2362,7 @@
               hide('consenter-exhibit-link');
               break;
             case 'deactivated':
-              hideConsentFields();
+              // hidePostConsentFields();
               break;
           }
          }
@@ -2688,6 +2689,14 @@
       document.querySelector('#spanRequestingEntity').innerText = '[INSERT NAME]';
     }
 
+    function populateExhibitFormSignoffFields() {
+      var { fullName, consenter: { email, phone_number }} = consenterInfo;
+      document.querySelector('#txtExhibitFullname').value = fullName;
+      document.querySelector('#txtExhibitEmail').value = email;
+      document.querySelector('#txtExhibitPhone').value = phone_number;
+      document.querySelector('#txtExhibitSignature').value = 'My Signature';      
+    }
+
     /**
      * Fill out the exhibit form with an item from the consenters exhibit_forms collection.
      */
@@ -2704,6 +2713,8 @@
       const exhibit_form = exhibit_forms.find(ef => {
         return ef.entity_id == selectedEntity.entity_id;
       });
+
+      populateExhibitFormSignoffFields();
 
       if( ! exhibit_form) {
         return
@@ -2730,12 +2741,6 @@
           setValue('poc-phone', i, a.phone_number);
         }
       }
-
-      var { fullName, consenter: { email, phone_number }} = consenterInfo;
-      document.querySelector('#txtExhibitFullname').value = fullName;
-      document.querySelector('#txtExhibitEmail').value = email;
-      document.querySelector('#txtExhibitPhone').value = phone_number;
-      document.querySelector('#txtExhibitSignature').value = 'My Signature';
     }
 
     /**
@@ -3507,6 +3512,48 @@
       }
     }
 
+    const sendExhibitFormRequest = async () => {
+      if( ! selectedConsenter) {
+        alert('Please select a consenting individual');
+        return;
+      }
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      try {
+        const role = AccessJwtCookie.getRole().name;
+        const { entity } = userContext;
+        const { entity_id, entity_name } = (entity ?? {});
+
+        document.body.style.cursor = 'progress';
+        const response = await fetch(apiUri(role), {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify({ 
+              task: 'send-exhibit-form-request', 
+              parameters: { consenterEmail:selectedConsenter, entity_id } 
+            })
+          }
+        });
+
+        const package = await response.json();
+        document.body.style.cursor = 'default';
+
+        const { message, payload } = package;
+        if(payload.ok) {
+          alert('Request sent!');
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
+    }
 
     /**
      * This function serves as a utility object for processing JWTs received from cognito and the cookies they are stored in.
@@ -3802,6 +3849,10 @@
         }
       });
 
+      // Add an event handler for the button to send exhibit form requests to consenters.
+      $('#btnSendExhibitsRequest').on('click', async () => {
+        await sendExhibitFormRequest();
+      });
 
       if(selected_role == 'SYS_ADMIN') {
         await buildConfigurationsTable();

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -973,6 +973,7 @@
             <!---------------------------------------------------->
             <div id="app-section-CONSENTING_PERSON" style="display:none">
               <div style="font-weight: bold; position: relative; top: -40px;">Welcome <span id="CONSENTING_PERSON_username">[Insert Username]</span></div>
+              <div id="waitForAI" style="font-weight: bold; position: relative; top: -20px; display:none;">An authorized individual will provide to you a link for exhibit form entry soon.</span></div>
               <div style="overflow:auto">
                 <ul class="nav nav-tabs" id="consenter" role="tablist">
                   <li class="nav-item">
@@ -1498,8 +1499,15 @@
     
     const localTesting = () => /^STATIC_PARAMETERS_.*$/.test(STATIC_PARAMETERS);
     const clientId = () => { return STATIC_PARAMETERS.ROLES[selected_role].CLIENT_ID; }
-    const redirectUri = () => { return STATIC_PARAMETERS.ROLES[selected_role].REDIRECT_URI; }
     const apiUri = () => { return STATIC_PARAMETERS.ROLES[selected_role].API_URI; }
+    const redirectUri = () => {
+      const defaultUri = STATIC_PARAMETERS.ROLES[selected_role].REDIRECT_URI;
+      if(selected_role == 'CONSENTING_PERSON' && document.location.pathname == '/consenter/exhibits/index.htm') {
+        const domain = defaultUri.substring(0, defaultUri.indexOf('/'));
+        return `${domain}/consenter/exhibits/index.htm`;
+      }
+      return defaultUri;
+    }
 
     const roleChange = () => {
       selected_role = document.forms['formRole']['rdoRole'].value;
@@ -1526,6 +1534,9 @@
     let RefreshJwtCookie;
 
     const getSelectedRole = () => {
+      if(document.location.pathname == '/consenter/exhibits/index.htm') {
+        return 'CONSENTING_PERSON';
+      }
       let role = new URL(document.location.href).searchParams.get('selected_role');
       if(role) return role;
       if(AccessJwtCookie && !AccessJwtCookie.jwtExpired()) {
@@ -2259,7 +2270,15 @@
             show('consentRenew');
             show('consentCorrect');
             show('consentSend');
-            show('consenter-exhibit-link');
+            if(document.location.pathname == '/consenter/exhibits/index.htm') {
+              show('consenter-exhibit-link');
+              document.getElementById('waitForAI').style.display = 'none';
+              document.getElementById('consenter-exhibit-link').click();
+            }
+            else {
+              hide('consenter-exhibit-link');
+              document.getElementById('waitForAI').style.display = 'inline';
+            }
             show('consentOptions');
             hide('consentFieldSet');
             fill('consentSendEmail', email);
@@ -3428,7 +3447,7 @@
           return;
         }
         const expires = `; expires=${expirationDate.toUTCString()}`;
-        const cookieValue = encodeURIComponent(jwt) + expires + secureFlag + '; SameSite=Strict';
+        const cookieValue = encodeURIComponent(jwt) + expires + secureFlag + '; path=/; SameSite=Strict';
         document.cookie = `${cookieName}=${cookieValue}`;
         // Now that the cookie is set and we have the JWT, we don't need the state and code verfier values anymore.
         const storage = window.sessionStorage;
@@ -3650,7 +3669,7 @@
         $(this).tab('show')
       });
 
-      // Add show/hide behavior to the RE_ADMIN tabstrip
+      // Add show/hide behavior to the CONSENTER tabstrip
       $('#consenter a').on('click', function (e) {
         e.preventDefault()
         $(this).tab('show')
@@ -3791,6 +3810,10 @@
           setName(AccessJwtCookie.getRole(), IDJwtCookie.getUser())
           await showAppForRole();        
         }
+        else if(document.location.pathname == '/consenter/exhibits/index.htm') {
+          // Not signed in and is consenter coming in on the "private" link emailed to them by AI
+          signIn(); 
+        }
         else if(!RefreshJwtCookie.jwtExpired()) {
           // TODO: Use the refresh token to restore access.
           console.log('Token refresh not implemented yet.');
@@ -3827,8 +3850,12 @@
 
         case 'login':
           await exchangeAuthorizationCode(checkAuth);
-          // Redirect back to the plain root url to shed the action, code, and state parameters
-          document.location.href = document.location.origin;
+          // Redirect back to the root url and path (minus querystring) to shed the action, code, and state parameters
+          let href = document.location.origin;
+          if(document.location.pathname == '/consenter/exhibits/index.htm') {
+            href = `${href}/consenter/exhibits/index.htm`;
+          }
+          document.location.href = href;
           break;
 
         case 'post-signup':

--- a/lib/Cloudfront.ts
+++ b/lib/Cloudfront.ts
@@ -1,9 +1,12 @@
+import { RemovalPolicy } from 'aws-cdk-lib';
+import { CachePolicy, CfnDistribution, CfnOriginAccessControl, Distribution, EdgeLambda, LambdaEdgeEventType, experimental } from 'aws-cdk-lib/aws-cloudfront';
+import { HttpOrigin, S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import { Code, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Bucket, ObjectOwnership } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { IContext } from '../contexts/IContext';
-import { Distribution, CfnOriginAccessControl, CfnDistribution, CachePolicy } from 'aws-cdk-lib/aws-cloudfront';
-import { HttpOrigin, S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins';
-import { Bucket, ObjectOwnership } from 'aws-cdk-lib/aws-s3';
-import { RemovalPolicy } from 'aws-cdk-lib';
+import path = require('path');
 
 export interface CloudfrontConstructProps {
   bucket: Bucket,
@@ -11,6 +14,8 @@ export interface CloudfrontConstructProps {
 };
 
 export class CloudfrontConstruct extends Construct {
+
+  public static EDGE_VIEWER_REQUEST_CODE_FILE:string = 'cdk.out/asset.viewer.request/index.js';
 
   constructId: string;
   scope: Construct;
@@ -37,15 +42,21 @@ export class CloudfrontConstruct extends Construct {
         autoDeleteObjects: true,
         objectOwnership: ObjectOwnership.OBJECT_WRITER
       }),
-      additionalBehaviors: {
-        // '*.htm': {
-        '*.*': {
-          origin: new S3Origin(props.bucket),
-          cachePolicy: CachePolicy.CACHING_DISABLED
-        }
-      }
-    });      
+    });
 
+    // Create an lambda@edge viewer request function that can rewrite paths to the origin
+    const edgeLambdas = [] as EdgeLambda[];
+    createEdgeFunctionForViewerRequest(this, this.context, (edgeLambda:any) => {
+      edgeLambdas.push(edgeLambda);
+    });
+
+    // Create a behavior that targets the s3 bucket as the origin
+    this.distribution.addBehavior('*.*', new S3Origin(props.bucket), {
+      cachePolicy: CachePolicy.CACHING_DISABLED,
+      edgeLambdas
+    });
+
+    // Give cloudfront access to the bucket
     const oac = new CfnOriginAccessControl(this, 'StaticSiteAccessControl', {
       originAccessControlConfig: {
         name: `${STACK_ID}-${landscape}-static-site`,
@@ -77,4 +88,56 @@ export class CloudfrontConstruct extends Construct {
   public getDistributionDomainName(): string {
     return this.distribution.domainName;
   }
+}
+
+/**
+ * Create the Lambda@Edge viewer response function.
+ * It can be bundled as normal because the stack is in the correct region.
+ */
+const createSameRegionEdgeFunction = (stack:CloudfrontConstruct, context:IContext):NodejsFunction => {
+  const { STACK_ID, TAGS: { Landscape } } = context;
+  const ftn = new NodejsFunction(stack, 'edge-function-viewer-response', {
+    runtime: Runtime.NODEJS_18_X,
+    entry: 'lib/lambda/functions/cloudfront/ViewerRequest.ts',
+    functionName: `${STACK_ID}-${Landscape}-bucket-origin-viewer-request-at-edge`,
+  });
+  return ftn;
+};
+
+/**
+ * Create the Lambda@Edge origin request function.
+ * It must be created in us-east-1, which, since this stack is NOT being
+ * created in us-east-1, requires the experimental EdgeFunction and a prebundled code asset.
+ * SEE: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-edge-function-restrictions.html
+ * 
+ * @param scope 
+ * @param context 
+ * @returns 
+ */
+const createCrossRegionEdgeFunction = (scope:CloudfrontConstruct, context:IContext):experimental.EdgeFunction => {
+  const { STACK_ID, TAGS: { Landscape } } = context;
+  const { EDGE_VIEWER_REQUEST_CODE_FILE:outfile } = CloudfrontConstruct;
+  const ftn = new experimental.EdgeFunction(scope, 'BucketOriginViewerRequestFunction', {
+    runtime: Runtime.NODEJS_18_X,
+    handler: 'index.handler',
+    code: Code.fromAsset(path.join(__dirname, `../${path.dirname(outfile)}`)),
+    functionName: `${STACK_ID}-${Landscape}-bucket-origin-viewer-request-at-edge`
+  });
+  return ftn;
+}
+
+export const createEdgeFunctionForViewerRequest = (scope:CloudfrontConstruct, context:IContext, callback:(lambda:EdgeLambda) => void) => {
+  const { REGION } = context;
+  let edgeFunction:NodejsFunction|experimental.EdgeFunction;
+  if(REGION == 'us-east-1') {
+    edgeFunction = createSameRegionEdgeFunction(scope, context);
+  }
+  else {
+    edgeFunction = createCrossRegionEdgeFunction(scope, context);
+  }
+
+  callback({
+    eventType: LambdaEdgeEventType.VIEWER_REQUEST,
+    functionVersion: edgeFunction.currentVersion
+  });
 }

--- a/lib/DynamoDb.ts
+++ b/lib/DynamoDb.ts
@@ -137,7 +137,12 @@ export class DynamoDbConstruct extends Construct {
           partitionKey: { name: ConsenterFields.active, type: AttributeType.STRING },
           sortKey: { name: ConsenterFields.email, type: AttributeType.STRING },
           projectionType: ProjectionType.INCLUDE,
-          nonKeyAttributes: [ ConsenterFields.email, ConsenterFields.sub ]
+          nonKeyAttributes: [ 
+            ConsenterFields.email, 
+            ConsenterFields.sub, 
+            ConsenterFields.firstname, 
+            ConsenterFields.middlename, 
+            ConsenterFields.lastname ]
         }
       ]
     } as TablePropsV2);

--- a/lib/lambda/Utils.ts
+++ b/lib/lambda/Utils.ts
@@ -309,6 +309,22 @@ export function ComparableDate(timestamp:any):any {
 }
 
 
+/** 
+ * Get the most recent date from an array of iso formatted date strings 
+ */
+export const getMostRecent = (timestamps:string[]=[]):string|undefined => {
+  if(timestamps.length == 0) {
+    return undefined;
+  }
+  timestamps.sort((a:string, b:string):number => {
+    const dateA = new Date(a);
+    const dateB = new Date(b);
+    return dateB.getTime() - dateA.getTime();
+  });
+  return timestamps[0];
+}
+
+
 /**
  * Turn an object like 
  *   { fldname1: { L: [{ M: { fldname2: { S: 'fld-value' }}}] }} 

--- a/lib/lambda/Utils.ts
+++ b/lib/lambda/Utils.ts
@@ -46,7 +46,6 @@ const getResponse = (message:string, statusCode:number, payload?:any): LambdaPro
   }
   addCorsHeaders(headers);
   const body = { message } as any;
-  console.log(message);
   if(payload) {
     body.payload = payload;
   }
@@ -56,7 +55,13 @@ const getResponse = (message:string, statusCode:number, payload?:any): LambdaPro
     headers,
     body: JSON.stringify(body)
   };
-  debugLog(response);
+  log(message);
+  if(payload && payload instanceof Error) {
+    log(payload);
+  }
+  else {
+    debugLog(response);
+  }
   return response;
 }
 
@@ -105,6 +110,24 @@ export const errorResponse = (message:string, payload?:any): LambdaProxyIntegrat
   return response;
 }
 
+export const debugLog = (o:any) => {
+  if(process.env.DEBUG == 'true') {
+    log(o);
+  }
+}
+
+export const log = (o:any) => {
+  if(o instanceof Error) {
+    console.error(JSON.stringify(o, Object.getOwnPropertyNames(o), 2));
+    return;
+  }
+  if(o instanceof Array) {
+    console.log(JSON.stringify(o, null, 2))
+    return;
+  }
+  console.log(o);
+}
+
 export const mergeResponses = (responses:LambdaProxyIntegrationResponse[]) => {
   // 1) Condense the response bodies into an array of their parsed values.
   const bodies = responses.map(response => {
@@ -132,18 +155,6 @@ export const mergeResponses = (responses:LambdaProxyIntegrationResponse[]) => {
 
 export const isOk = (response:LambdaProxyIntegrationResponse) => {
   return /^2\d+/.test(`${response.statusCode}`);
-}
-
-export const log = (o:any) => {
-  if(o instanceof Error) {
-    console.error(JSON.stringify(o, Object.getOwnPropertyNames(o), 2));
-    return;
-  }
-  if(o instanceof Array) {
-    console.log(JSON.stringify(o, null, 2))
-    return;
-  }
-  console.log(o);
 }
 
 /**
@@ -238,12 +249,6 @@ export const bytesToBase64 = (bytes:Uint8Array) => {
     String.fromCodePoint(byte),
   ).join("");
   return btoa(binString);
-}
-
-export const debugLog = (o:any) => {
-  if(process.env.DEBUG == 'true') {
-    log(o);
-  }
 }
 
 export const viewHtml = async (html:string) => {

--- a/lib/lambda/_lib/dao/db-update-builder.consenter.ts
+++ b/lib/lambda/_lib/dao/db-update-builder.consenter.ts
@@ -38,22 +38,39 @@ export const consenterUpdate = (TableName:string, _new:Consenter, old:Consenter=
     const updates = [] as any[];
     for(fld in ConsenterFields) {
       if(key[fld]) continue;
-      if(fld == ConsenterFields.exhibit_forms) {
-        const newForms = _new.exhibit_forms ?? [];
-        const oldForms = old.exhibit_forms ?? [];
-        if( ! deepEquals(newForms, oldForms)) {
+      switch(fld) {
+
+        case ConsenterFields.exhibit_forms:
+          const newForms = _new.exhibit_forms ?? [];
+          const oldForms = old.exhibit_forms ?? [];
+          if( ! deepEquals(newForms, oldForms)) {
+            input.ExpressionAttributeNames![`#${fld}`] = fld;
+            input.ExpressionAttributeValues![`:${fld}`] = convertToApiObject(newForms);
+            updates.push({ [`#${fld}`]: `:${fld}`});
+          }
+          break;
+
+        case ConsenterFields.consented_timestamp:
+        case ConsenterFields.renewed_timestamp:
+        case ConsenterFields.rescinded_timestamp:
+          if( ! _new[fld]) continue;
           input.ExpressionAttributeNames![`#${fld}`] = fld;
-          input.ExpressionAttributeValues![`:${fld}`] = convertToApiObject(newForms);
+          let converted = convertToApiObject(_new[fld]);
+          if( ! converted || Object.keys(converted).length == 0) {
+            converted = { L: [] }; // Prefer an empty array over an empty object
+          }
+          input.ExpressionAttributeValues![`:${fld}`] = converted;
           updates.push({ [`#${fld}`]: `:${fld}`});
-        }
-      }
-      else {
-        if( ! _new[fld]) continue;
-        if(_new[fld] != old[fld]) { // Add to expressions only if the field has changed in value.
-          input.ExpressionAttributeNames![`#${fld}`] = fld;
-          input.ExpressionAttributeValues![`:${fld}`] = wrap(_new[fld]);
-          updates.push({ [`#${fld}`]: `:${fld}`});
-        }
+          break;
+
+        default:
+          if( ! _new[fld]) continue;
+          if(_new[fld] != old[fld]) { // Add to expressions only if the field has changed in value.
+            input.ExpressionAttributeNames![`#${fld}`] = fld;
+            input.ExpressionAttributeValues![`:${fld}`] = wrap(_new[fld]);
+            updates.push({ [`#${fld}`]: `:${fld}`});
+          }
+          break;
       }
     }
 

--- a/lib/lambda/_lib/dao/entity.ts
+++ b/lib/lambda/_lib/dao/entity.ts
@@ -89,9 +89,9 @@ export type Consenter = {
   phone_number?: string,
   create_timestamp?: string,
   update_timestamp?: string,
-  consented_timestamp?: string,
-  rescinded_timestamp?: string,
-  renewed_timestamp?: string,
+  consented_timestamp: string[],
+  rescinded_timestamp: string[],
+  renewed_timestamp: string[],
   exhibit_forms?: ExhibitForm[],
   active?: Y_or_N
 };

--- a/lib/lambda/_lib/pdf/ConsentForm.ts
+++ b/lib/lambda/_lib/pdf/ConsentForm.ts
@@ -61,7 +61,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_CONSENT_FORM') {
     entityName: 'Boston University',
     consenter: { 
       email: 'bugsbunny@warnerbros.com', firstname: 'Bugs', middlename: 'B', lastname: 'Bunny',
-      phone_number: '617-333-5555', consented_timestamp: new Date().toISOString(), active: YN.Yes
+      phone_number: '617-333-5555', consented_timestamp: [ new Date().toISOString() ], active: YN.Yes
     } as Consenter
   } as ConsentFormData).writeToDisk('./lib/lambda/_lib/pdf/consentForm.pdf')
   .then((bytes) => {

--- a/lib/lambda/_lib/pdf/ConsentFormPage1.ts
+++ b/lib/lambda/_lib/pdf/ConsentFormPage1.ts
@@ -151,7 +151,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_CONSENT_FORM_PAGE_1') {
     entityName: 'Boston University',
     consenter: { 
       email: 'bugsbunny@warnerbros.com', firstname: 'Bugs', middlename: 'B', lastname: 'Bunny',
-      phone_number: '617-333-5555', consented_timestamp: new Date().toISOString(), active: YN.Yes
+      phone_number: '617-333-5555', consented_timestamp: [ new Date().toISOString() ], active: YN.Yes
     } as Consenter
   } as ConsentFormData).writeToDisk('./lib/lambda/_lib/pdf/consentForm1.pdf')
   .then((bytes) => {

--- a/lib/lambda/_lib/pdf/ConsentFormPage3.ts
+++ b/lib/lambda/_lib/pdf/ConsentFormPage3.ts
@@ -6,6 +6,7 @@ import { EmbeddedFonts } from "./lib/EmbeddedFonts";
 import { Page } from "./lib/Page";
 import { Align, Margins, VAlign, rgbPercent } from "./lib/Utils";
 import { Consenter, YN } from "../dao/entity";
+import { getMostRecent } from "../../Utils";
 
 const blue = rgbPercent(47, 84, 150) as Color;
 const grey = rgb(.1, .1, .1) as Color;
@@ -185,8 +186,9 @@ export class ConsentFormPage3 extends PdfForm implements IPdfForm {
       },
       textOptions: { size:14, font:boldfont, color:white, lineHeight: 16 }
     });
+    const most_recent_consent = getMostRecent(consented_timestamp);
     await drawRectangle({
-      text: consented_timestamp ? new Date(consented_timestamp).toLocaleDateString() : 'unknown',
+      text: most_recent_consent ? new Date(most_recent_consent).toLocaleDateString() : 'unknown',
       page, margins: { left:6, top:6, bottom:0, right:6 },
       align: Align.left, valign: VAlign.middle,
       options: {
@@ -212,7 +214,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_CONSENT_FORM_PAGE_3') {
     entityName: 'Boston University',
     consenter: { 
       email: 'bugsbunny@warnerbros.com', firstname: 'Bugs', middlename: 'B', lastname: 'Bunny',
-      phone_number: '617-333-5555', consented_timestamp: new Date().toISOString(), active: YN.Yes
+      phone_number: '617-333-5555', consented_timestamp: [ new Date().toISOString() ], active: YN.Yes
     } as Consenter
   } as ConsentFormData).writeToDisk('./lib/lambda/_lib/pdf/consentForm3.pdf')
   .then((bytes) => {

--- a/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
+++ b/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
@@ -6,7 +6,7 @@ import { lookupUserPoolId } from "../../_lib/cognito/Lookup";
 import { Configurations } from "../../_lib/config/Config";
 import { DAOFactory, DAOUser } from "../../_lib/dao/dao";
 import { ENTITY_WAITING_ROOM } from "../../_lib/dao/dao-entity";
-import { ConfigNames, Entity, Roles, User } from "../../_lib/dao/entity";
+import { ConfigNames, Consenter, Entity, Roles, User } from "../../_lib/dao/entity";
 import { DelayedLambdaExecution } from "../../_lib/timer/DelayedExecution";
 import { EggTimer, PeriodType } from "../../_lib/timer/EggTimer";
 import { debugLog, errorResponse, invalidResponse, log, lookupCloudfrontDomain, okResponse } from "../../Utils";
@@ -212,7 +212,7 @@ export const sendDisclosureRequest = async (consenterEmail:string, entity_id:str
     return errorResponse('Cannot determine disclosure request lambda function arn from environment!');
   }
 
-  const metadata = new BucketItemMetadata(new BucketItem({ email:consenterEmail }));
+  const metadata = new BucketItemMetadata(new BucketItem({ email:consenterEmail } as Consenter));
   const { EXHIBIT, DISCLOSURE } = ItemType;
 
   const s3ObjectKeyForExhibitForm = await metadata.getLatestS3ObjectKey({
@@ -269,7 +269,7 @@ export const sendDisclosureRequest = async (consenterEmail:string, entity_id:str
 
   // Tag the pdfs so that they are skipped over by the event bridge stale pdf purging rule:
   const now = new Date().toISOString();
-  const bucketItem = new BucketItem({ email:consenterEmail });
+  const bucketItem = new BucketItem({ email:consenterEmail } as Consenter);
   let tagged = false;
   tagged ||= await bucketItem.tag(s3ObjectKeyForExhibitForm, Tags.DISCLOSED, now);  
   tagged &&= await bucketItem.tag(s3ObjectKeyForDisclosureForm, Tags.DISCLOSED, now);

--- a/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
@@ -107,14 +107,14 @@ const grabFromBucketAndSend = async (parms:DisclosureEmailParms):Promise<boolean
   }
   const singleExhibitForm = new class implements IPdfForm {
     async getBytes(): Promise<Uint8Array> {
-      const bucket = new ExhibitBucket(new BucketItem({ email:consenterEmail }, 'ett-dev-exhibit-forms'));
+      const bucket = new ExhibitBucket(new BucketItem({ email:consenterEmail } as Consenter, 'ett-dev-exhibit-forms'));
       return bucket.get(s3ObjectKeyForExhibitForm);
     }
   }();
 
   const disclosureForm = new class implements IPdfForm {
     async getBytes(): Promise<Uint8Array> {
-      const bucket = new DisclosureFormBucket(new BucketItem({ email:consenterEmail }, 'ett-dev-exhibit-forms'));
+      const bucket = new DisclosureFormBucket(new BucketItem({ email:consenterEmail } as Consenter, 'ett-dev-exhibit-forms'));
       return bucket.get(s3ObjectKeyForDisclosureForm);
     }
   }();
@@ -190,7 +190,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_SEND_DISCLOSURE_FORM') {
   const test_disclosure_data = {
     consenter: { 
       email: 'foghorn@warnerbros.com', phone_number: '617-222-4444', active: YN.Yes,
-      firstname: 'Foghorn', middlename: 'F', lastname: 'Leghorn', consented_timestamp: new Date().toISOString()
+      firstname: 'Foghorn', middlename: 'F', lastname: 'Leghorn', consented_timestamp: [ new Date().toISOString() ]
     },
     disclosingEntity: { name: 'Boston University', representatives: [ daffyduck, yosemitesam ] },
     requestingEntity: { name: 'Northeastern University', authorizedIndividuals: [ bugsbunny ] }

--- a/lib/lambda/functions/authorized-individual/ExhibitFormRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/ExhibitFormRequestEmail.ts
@@ -1,0 +1,85 @@
+import { IContext } from "../../../../contexts/IContext";
+import { DAOFactory } from "../../_lib/dao/dao";
+import { Consenter, Entity, YN } from "../../_lib/dao/entity";
+import { EmailParms, sendEmail } from "../../_lib/EmailWithAttachments";
+import { PdfForm } from "../../_lib/pdf/PdfForm";
+import { lookupCloudfrontDomain } from "../../Utils";
+
+
+export class ExhibitFormRequestEmail {
+  private consenterEmail:string;
+  private entity_id:string;
+  private domain:string;
+
+  constructor(consenterEmail:string, entity_id:string, domain:string) {
+    this.consenterEmail = consenterEmail;
+    this.entity_id = entity_id;
+    this.domain = domain;
+  }
+
+  public send = async ():Promise<boolean> => {
+    const { consenterEmail, entity_id, domain } = this;
+
+    // Get the consenter
+    const consenterDao = DAOFactory.getInstance({ DAOType: 'consenter', Payload: { email: consenterEmail} as Consenter});
+    const consenter = await consenterDao.read() as Consenter;
+    const { firstname, middlename, lastname, active:activeConsenter } = consenter;
+    if(activeConsenter == YN.No) {
+      console.log(`Cannot send exhibit form request to ${consenterEmail} for ${entity_id} because consenter is inactive`);
+      return false;
+    }
+    const consenterFullName = PdfForm.fullName(firstname, middlename, lastname);
+
+    // Get the entity
+    const entityDao = DAOFactory.getInstance({ DAOType: 'entity', Payload: { entity_id } as Entity });
+    const entity = await entityDao.read() as Entity;
+    const { entity_name, active:activeEntity } = entity;
+    if(activeEntity == YN.No) {
+      console.log(`Cannot send exhibit form request to ${consenterEmail} for ${entity_id} because entity is inactive`);
+      return false;
+    }
+  
+    return sendEmail({
+      subject: `ETT Exhibit Form Request`,
+      message: `Thankyou ${consenterFullName} for registering with the Ethical Tranparency Tool.<br>` +
+        `${entity_name} is requesting you take the next step and fill out a prior contacts or "exhibit" form.<br>` +
+        `Follow the link provided below to log in to your ETT account and to access the form:` + 
+        `<p>https://${domain}/consenter/exhibits/index.htm</p>`,
+      emailAddress:consenterEmail,
+      attachments: []
+    } as EmailParms);
+  
+  }
+}
+
+
+
+
+/**
+ * RUN MANUALLY: Modify email as needed.
+ */
+const { argv:args } = process;
+if(args.length > 2 && args[2] == 'RUN_MANUALLY_SEND_EXHIBIT_FORM_REQUEST') {
+
+  const consenterEmail = 'cp1@warhen.work';
+  const entity_id = '3ef70b3e-456b-42e8-86b0-d8fbd0066628';
+
+  (async() => {
+    // 1) Get context variables
+    const context:IContext = await require('../../../../contexts/context.json');
+    const { REGION, TAGS: { Landscape }} = context;
+    process.env.REGION = REGION;
+
+    // 1) Gt the cloudfront domain
+    const cloudfrontDomain = await lookupCloudfrontDomain(Landscape);
+    if( ! cloudfrontDomain) {
+      throw('Cloudfront domain lookup failure');
+    }
+    process.env.CLOUDFRONT_DOMAIN = cloudfrontDomain;
+    
+    await new ExhibitFormRequestEmail(consenterEmail, entity_id, cloudfrontDomain).send();
+
+    console.log('Email sent!');
+  })();
+
+}

--- a/lib/lambda/functions/cloudfront/ViewerRequest.ts
+++ b/lib/lambda/functions/cloudfront/ViewerRequest.ts
@@ -1,0 +1,28 @@
+
+/**
+ * This is a lambda@edge function for viewer request traffic to the ETT content bucket origin.
+ * The purpose of this function is simply to intercept requests that match a specific uri and rewrite them to predefined value.
+ * This way, more than one path can "point" to the same item in the origin bucket.
+  */
+export const handler =  async (event:any) => {
+
+  try {
+    const request = event.Records[0].cf.request;
+    const uri = request.uri;
+
+    // Rewrite the request to the root index.htm if the path follows predefined patterns:
+    if(`${uri}`.startsWith('/consenter/exhibits/')) {
+      const parts = uri.split('/');
+      const item = parts[parts.length-1];
+      request.uri = `/${item}`;
+    }
+
+    return request;
+  } 
+  catch (e:any) {
+    return {
+      status: 501,
+      body: `Viewer request lambda error: ${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}`
+    }
+  }
+}

--- a/lib/lambda/functions/consenting-person/BucketExhibitForms.ts
+++ b/lib/lambda/functions/consenting-person/BucketExhibitForms.ts
@@ -288,7 +288,7 @@ if(args.length > 4 && args[2] == 'RUN_MANUALLY_CONSENTER_BUCKET_ITEM') {
     firstname: 'Elmer',
     middlename: 'F',
     lastname: 'Fudd',
-    consented_timestamp: dummyDateString,
+    consented_timestamp: [ dummyDateString ],
     phone_number: '617-444-6666', 
     title: 'Wabbit Hunter',
     exhibit_forms: [

--- a/lib/lambda/functions/consenting-person/ConsentEmail.ts
+++ b/lib/lambda/functions/consenting-person/ConsentEmail.ts
@@ -52,7 +52,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_SEND_CONSENT_FORM') {
   const test_consenter_form_data = {
     entityName: 'Boston University',
     consenter: {
-      email, active: YN.Yes, consented_timestamp: new Date().toISOString(),
+      email, active: YN.Yes, consented_timestamp: [ new Date().toISOString() ],
       firstname: 'Bugs', middlename: 'B', lastname: 'Bunny', title: 'Rabbit',
       phone_number: '+617-222-4444', 
     }

--- a/lib/lambda/functions/consenting-person/ConsentingPerson.mocks.ts
+++ b/lib/lambda/functions/consenting-person/ConsentingPerson.mocks.ts
@@ -157,7 +157,7 @@ export function DaoMock(originalModule: any) {
                 switch(consentState) {
                   case ConsentState.OK:
                     consenter = Object.assign(consenter, sylvesterTheCat);
-                    consenter.consented_timestamp = new Date().toISOString();
+                    consenter.consented_timestamp = [ new Date().toISOString() ];
                     break;
                   case ConsentState.NONE:
                     consenter = Object.assign(consenter, sylvesterTheCat);
@@ -165,18 +165,18 @@ export function DaoMock(originalModule: any) {
                   case ConsentState.RESCINDED:
                     consented = new Date(retracted.getTime() - day);
                     consenter = Object.assign(consenter, sylvesterTheCat);
-                    consenter.consented_timestamp = consented.toISOString();
-                    consenter.rescinded_timestamp = retracted.toISOString();
+                    consenter.consented_timestamp = [ consented.toISOString() ];
+                    consenter.rescinded_timestamp = [ retracted.toISOString() ];
                     break;
                   case ConsentState.RESTORED:
                     consented = new Date(retracted.getTime() + day);
                     consenter = Object.assign(consenter, sylvesterTheCat);
-                    consenter.consented_timestamp = consented.toISOString();
-                    consenter.rescinded_timestamp = retracted.toISOString();
+                    consenter.consented_timestamp = [ consented.toISOString() ];
+                    consenter.rescinded_timestamp = [ retracted.toISOString() ];
                     break;
                   case ConsentState.INACTIVE:
                     consenter = Object.assign(consenter, sylvesterTheCat);
-                    consenter.consented_timestamp = new Date().toISOString();
+                    consenter.consented_timestamp = [ new Date().toISOString() ];
                     consenter.active = YN.No;
                     break;
                   default:

--- a/lib/lambda/functions/consenting-person/ConsentingPerson.ts
+++ b/lib/lambda/functions/consenting-person/ConsentingPerson.ts
@@ -313,7 +313,7 @@ export const rescindConsent = async (email:string): Promise<LambdaProxyIntegrati
   return appendTimestamp(
     consenterInfo.consenter, 
     ConsenterFields.rescinded_timestamp,
-    YN.Yes
+    YN.No
   );
 
   // TODO: Blank out exhibit forms in db and bucket, and purge the userpool record (client script must also log out).

--- a/lib/lambda/functions/consenting-person/ConsentingPerson.ts
+++ b/lib/lambda/functions/consenting-person/ConsentingPerson.ts
@@ -11,7 +11,7 @@ import { ConsentFormData } from "../../_lib/pdf/ConsentForm";
 import { PdfForm } from "../../_lib/pdf/PdfForm";
 import { DelayedLambdaExecution } from "../../_lib/timer/DelayedExecution";
 import { EggTimer, PeriodType } from "../../_lib/timer/EggTimer";
-import { ComparableDate, debugLog, deepClone, errorResponse, invalidResponse, log, lookupCloudfrontDomain, okResponse } from "../../Utils";
+import { ComparableDate, debugLog, deepClone, errorResponse, getMostRecent, invalidResponse, log, lookupCloudfrontDomain, okResponse } from "../../Utils";
 import { DisclosureFormBucket } from "./BucketDisclosureForms";
 import { ExhibitBucket } from "./BucketExhibitForms";
 import { BucketItem, DisclosureItemsParms } from "./BucketItem";
@@ -109,16 +109,17 @@ export const handler = async (event:any):Promise<LambdaProxyIntegrationResponse>
 
 /**
  * Get a consenters database record.
- * @param email 
+ * @param parm 
  * @returns 
  */
-export const getConsenterResponse = async (email:string, includeEntityList:boolean=true): Promise<LambdaProxyIntegrationResponse> => {
+export const getConsenterResponse = async (parm:string|Consenter, includeEntityList:boolean=true): Promise<LambdaProxyIntegrationResponse> => {
+  const email = (typeof (parm ?? '') == 'string') ? parm as string : (parm as Consenter).email;
   if( ! email) {
     return invalidResponse(INVALID_RESPONSE_MESSAGES.missingEmail)
   }
-  const consenterInfo = await getConsenter(email, includeEntityList);
+  const consenterInfo = await getConsenterInfo(parm, includeEntityList);
   if( ! consenterInfo) {
-    return okResponse(`No such consenter: ${email}`);
+    return okResponse(`No such consenter: ${parm}`);
   }
   return okResponse('Ok', consenterInfo);
 }
@@ -129,21 +130,24 @@ export const getConsenterResponse = async (email:string, includeEntityList:boole
  * @returns 
  */
 export const isActiveConsent = (consenter:Consenter):boolean => {
+
   const { consented_timestamp, rescinded_timestamp, renewed_timestamp, active } = consenter;
+  const consented = getMostRecent(consented_timestamp);
   let activeConsent:boolean = false;
-  if(consented_timestamp && `${active}` == YN.Yes) {
+  if(consented && `${active}` == YN.Yes) {
+    const rescinded = getMostRecent(rescinded_timestamp);
+    const renewed = getMostRecent(renewed_timestamp);
+    const consentedDate = ComparableDate(consented);
+    const rescindedDate = ComparableDate(rescinded);
+    const renewedDate = ComparableDate(renewed);
 
-    const consented = ComparableDate(consented_timestamp);
-    const rescinded = ComparableDate(rescinded_timestamp);
-    const renewed = ComparableDate(renewed_timestamp);
-
-    if(consented.after(rescinded) && consented.after(renewed)) {
+    if(consentedDate.after(rescindedDate) && consentedDate.after(renewedDate)) {
       activeConsent = true; // Consent was given
     }
-    if(renewed.after(consented) && renewed.after(rescinded)) {
+    if(renewedDate.after(consentedDate) && renewedDate.after(rescindedDate)) {
       activeConsent = true; // Consent was rescinded but later restored
     }
-    if(rescinded.after(consented) && rescinded.after(renewed)) {
+    if(rescindedDate.after(consentedDate) && rescindedDate.after(renewedDate)) {
       activeConsent = false; // Consent was rescinded
     }
   }
@@ -151,13 +155,19 @@ export const isActiveConsent = (consenter:Consenter):boolean => {
 }
 
 /**
- * Get a consenters database record.
- * @param email 
+ * Get a consenters database record and wrap it in extra computed data.
+ * @param parm 
  * @returns 
  */
-export const getConsenter = async (email:string, includeEntityList:boolean=true): Promise<ConsenterInfo|null> => {
-  const dao = DAOFactory.getInstance({ DAOType: 'consenter', Payload: { email } as Consenter });
-  const consenter = await dao.read({ convertDates: false }) as Consenter;
+export const getConsenterInfo = async (parm:string|Consenter, includeEntityList:boolean=true): Promise<ConsenterInfo|null> => {
+  let consenter;
+  if(typeof parm == 'string') {
+    const dao = DAOFactory.getInstance({ DAOType: 'consenter', Payload: { email:parm } as Consenter });
+    consenter = await dao.read({ convertDates: false }) as Consenter;
+  }
+  else {
+    consenter = parm as Consenter;
+  }
   if( ! consenter) {
     return null;
   }
@@ -191,23 +201,34 @@ export const getConsenter = async (email:string, includeEntityList:boolean=true)
 }
 
 /**
- * Change one of the timestamp fields of the consenter.
+ * Append to one of the timestamp array fields of the consenter.
  * @param email 
- * @param timestampFld 
+ * @param timestampFldName 
  * @returns 
  */
-export const changeTimestamp = async (email:string, timestampFld:string): Promise<LambdaProxyIntegrationResponse> => {
-  if( ! email) {
-    return invalidResponse(INVALID_RESPONSE_MESSAGES.missingEmail)
+export const appendTimestamp = async (consenter:Consenter, timestampFldName:ConsenterFields, active:YN): Promise<LambdaProxyIntegrationResponse> => {
+  if( ! consenter) {
+    return invalidResponse(INVALID_RESPONSE_MESSAGES.noSuchConsenter)
   }
-  const dao = DAOFactory.getInstance({ DAOType: 'consenter', Payload: { 
-    email, 
-    [ timestampFld ]: new Date().toISOString() 
-  } as Consenter });
 
+  // Append a new item to the specified timestamp array of the consenter object
+  const { email } = consenter;
+  const dte = new Date().toISOString();
+  if( ! consenter[timestampFldName]) {
+    consenter = Object.assign(consenter, { [timestampFldName]: [] as string[]})
+  }
+  (consenter[timestampFldName] as string[]).push(dte);
+  
+  // Apply the same change at the backend on the database record
+  const dao = DAOFactory.getInstance({ DAOType: 'consenter', Payload: {
+    email,
+    [timestampFldName]: consenter[timestampFldName],
+    active
+  } as unknown as Consenter });
   await dao.update();
   
-  return getConsenterResponse(email, false);
+  // Return a response with an updated consenter info payload
+  return getConsenterResponse(consenter, false);
 };
 
 /**
@@ -217,12 +238,23 @@ export const changeTimestamp = async (email:string, timestampFld:string): Promis
  */
 export const registerConsent = async (email:string): Promise<LambdaProxyIntegrationResponse> => {
   console.log(`Registering consent for ${email}`);
-  const response = await changeTimestamp(email, ConsenterFields.consented_timestamp);
-  const consenterInfo = JSON.parse(response.body ?? '{}')['payload'] as ConsenterInfo;
+  
+  // Abort if consenter lookup fails
+  let consenterInfo = await getConsenterInfo(email, false) as ConsenterInfo;
+  if( ! consenterInfo) {
+    return invalidResponse(INVALID_RESPONSE_MESSAGES.noSuchConsenter + ' ' + email );
+  }
+
+  const response = await appendTimestamp(
+    consenterInfo.consenter, 
+    ConsenterFields.consented_timestamp,
+    YN.Yes
+  );
+  consenterInfo = JSON.parse(response.body ?? '{}')['payload'] as ConsenterInfo;
   const { consenter } = consenterInfo ?? {};
   if(consenter) {
     // TODO: Mention of a specific entity in the consent form is in question and needs to be resolved with the client.
-    await sendConsent(consenter, 'unknown entity');
+    await sendConsent(consenter, 'any entity');
   }
   return response;
 }
@@ -234,17 +266,57 @@ export const registerConsent = async (email:string): Promise<LambdaProxyIntegrat
  */
 export const renewConsent = async (email:string): Promise<LambdaProxyIntegrationResponse> => {
   console.log(`Renewing consent for ${email}`);
-  return changeTimestamp(email, ConsenterFields.renewed_timestamp);
+  
+  // Abort if consenter lookup fails
+  let consenterInfo = await getConsenterInfo(email, true) as ConsenterInfo;
+  if( ! consenterInfo) {
+    return invalidResponse(INVALID_RESPONSE_MESSAGES.noSuchConsenter + ' ' + email );
+  }
+
+  // Abort if the consenter has not yet consented
+  // if( ! consenterInfo?.activeConsent) {
+  //   if(consenterInfo?.consenter?.active == YN.No) {
+  //     return invalidResponse(INVALID_RESPONSE_MESSAGES.inactiveConsenter);
+  //   }
+  //   return invalidResponse(INVALID_RESPONSE_MESSAGES.missingConsent);
+  // }
+
+  return appendTimestamp(
+    consenterInfo.consenter, 
+    ConsenterFields.renewed_timestamp,
+    YN.Yes
+  );
 }
 
 /**
- * Rescind consent by applying a rescinded_timestamp value to the consenter database record.
+ * Rescind consent by appending a rescinded_timestamp value to the consenter database record.
  * @param email 
  * @returns 
  */
 export const rescindConsent = async (email:string): Promise<LambdaProxyIntegrationResponse> => {
   console.log(`Rescinding consent for ${email}`);
-  return changeTimestamp(email, ConsenterFields.rescinded_timestamp);
+  
+  // Abort if consenter lookup fails
+  const consenterInfo = await getConsenterInfo(email, false) as ConsenterInfo;
+  if( ! consenterInfo) {
+    return invalidResponse(INVALID_RESPONSE_MESSAGES.noSuchConsenter + ' ' + email );
+  }
+
+  // Abort if the consenter has not yet consented
+  if( ! consenterInfo?.activeConsent) {
+    if(consenterInfo?.consenter?.active == YN.No) {
+      return invalidResponse(INVALID_RESPONSE_MESSAGES.inactiveConsenter);
+    }
+    return invalidResponse(INVALID_RESPONSE_MESSAGES.missingConsent);
+  }
+
+  return appendTimestamp(
+    consenterInfo.consenter, 
+    ConsenterFields.rescinded_timestamp,
+    YN.Yes
+  );
+
+  // TODO: Blank out exhibit forms in db and bucket, and purge the userpool record (client script must also log out).
 };
 
 /**
@@ -269,7 +341,7 @@ export const sendConsent = async (consenter:Consenter, entityName:string): Promi
   let consenterInfo:ConsenterInfo|null;
   if(email && Object.keys(consenter).length == 1) {
     // email was the only piece of information provided about the consenter, so retrieve the rest from the database.
-    consenterInfo = await getConsenter(email, false) as ConsenterInfo;
+    consenterInfo = await getConsenterInfo(email, false) as ConsenterInfo;
     if(consenterInfo) {
       const { consenter: { firstname, middlename, lastname}} = consenterInfo ?? { consenter: {}};
       consenterInfo = { 
@@ -309,7 +381,7 @@ export const saveExhibitData = async (email:string, exhibitForm:ExhibitForm): Pr
   }
 
   // Abort if consenter lookup fails
-  const consenterInfo = await getConsenter(email, false) as ConsenterInfo;
+  const consenterInfo = await getConsenterInfo(email, false) as ConsenterInfo;
   if( ! consenterInfo) {
     return invalidResponse(INVALID_RESPONSE_MESSAGES.noSuchConsenter + ' ' + email );
   }
@@ -470,7 +542,7 @@ export const sendExhibitData = async (email:string, exhibitForm:ExhibitForm): Pr
 
   const loadInfoFromDatabase = async () => {
     // Get the consenter
-    const consenterInfo = await getConsenter(email, false) as ConsenterInfo;
+    const consenterInfo = await getConsenterInfo(email, false) as ConsenterInfo;
     const { consenter: _consenter, activeConsent } = consenterInfo ?? {};
 
     // Abort if the consenter has not yet consented
@@ -633,7 +705,7 @@ export const correctExhibitData = async (email:string, exhibitForm:ExhibitForm):
 const { argv:args } = process;
 if(args.length > 2 && args[2] == 'RUN_MANUALLY_CONSENTING_PERSON') {
 
-  const task = Task.SEND_EXHIBIT_FORM as Task;
+  const task = Task.RESCIND_CONSENT as Task;
   let payload = {
     task,
     parameters: {

--- a/lib/lambda/functions/delayed-execution/TestBucketItem.ts
+++ b/lib/lambda/functions/delayed-execution/TestBucketItem.ts
@@ -10,7 +10,7 @@ export const getConsenter = (dummyDate:string) => {
   return {
     email: 'cp1@warhen.work',
     active: YN.Yes,
-    consented_timestamp: dummyDate,
+    consented_timestamp: [ dummyDate ],
     create_timestamp: dummyDate,
     firstname: 'Mickey',
     lastname: 'Mouse',

--- a/lib/lambda/functions/re-admin/ReAdminUser.ts
+++ b/lib/lambda/functions/re-admin/ReAdminUser.ts
@@ -369,12 +369,10 @@ export const inviteUser = async (user:User, inviterRole:Role, linkGenerator:Func
     // Send the invitation
     if( await emailInvite.send()) {
       const msg = `Invitation successfully sent: ${emailInvite.code}`
-      log(msg);
       return okResponse(msg, { invitation_code: emailInvite.code, invitation_link: emailInvite.link });
     }
     else {
       const msg = `Invitation failure: ${emailInvite.code}`;
-      log(msg);
       return errorResponse(msg);
     } 
   }

--- a/lib/lambda/functions/signup/ConsenterRegistration.ts
+++ b/lib/lambda/functions/signup/ConsenterRegistration.ts
@@ -38,7 +38,8 @@ export const handler = async(event:any):Promise<LambdaProxyIntegrationResponse> 
     log(`Registering ${email}`);
 
     const create_timestamp = new Date().toISOString();
-    const active = YN.Yes
+    // Set as inactive pending submission of consent form.
+    const active = YN.No
 
     // Lookup the consenter in case registration was interrupted and is being retried
     let dao = ConsenterCrud({ email, firstname, middlename, lastname, create_timestamp, active } as Consenter);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "tsc -w",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --silent",
     "cdk": "cdk",
-    "deploy": "cdk deploy --no-rollback --require-approval never",
+    "deploy": "cdk deploy --all --no-rollback --require-approval never",
     "redeploy": "cdk destroy -f && npm run deploy",
     "synth": "cdk synth 2>&1 | tee cdk.out/ett.template.yaml",
     "clearcache": "sh bin/clearcache.sh",


### PR DESCRIPTION
This pull request introduces a new feature to the dashboard of an authorized user (AI).
The added feature provides the following controls on the dashboard of an AI:

- A picklist of consenting individuals who have submitted their consent
- A button to send an email to the consenter selected from the picklist.

The email includes the request for the exhibit forms and a link for the consenter to follow that sends them to their dashboard using an unpublished route that is used to access the exhibit form submission feature.
That is to say, if the consenter logged in through the standard public route, their dashboard would not display any exhibit form entry.