### PR TITLE
Consenter correction

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -88,6 +88,21 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "ConsentingPersonCorrection",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/functions/consenting-person/Correction.ts",
+        "RUN_MANUALLY_CONSENTER_CORRECTION",
+      ], 
+      "env": {
+        "AWS_PROFILE": "bu",
+        "REGION": "us-east-2"
+      }, 
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "CognitoUserUpdate",
       "skipFiles": [ "<node_internals>/**" ],
       "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -88,6 +88,22 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "CognitoUserUpdate",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/_lib/cognito/UserAccount.ts",
+        "RUN_MANUALLY_COGNITO_USER_UPDATE",
+        "replace"
+      ], 
+      "env": {
+        "AWS_PROFILE": "bu",
+        "REGION": "us-east-2"
+      }, 
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "SendExhibitFormRequest",
       "skipFiles": [ "<node_internals>/**" ],
       "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -254,6 +254,28 @@
         padding-top:10px;
       }
 
+      #divConsenterCorrect > div {
+        float:left;
+        margin-top: 10px;
+        margin-left: 10px;
+        text-align: left;
+        font-size: 22px;
+        max-width:60%;
+      }
+      #divConsenterCorrect > div[label="true"] {
+        font-weight:bold;
+        clear:both;
+        width: 150px;
+        text-align: right;
+        font-size: 18px;
+        padding-top: 4px;
+      }
+      #divConsenterCorrect > div > p {
+        margin-top: 10px;
+        font-style: italic;
+        font-size: 16px;
+      }
+
       span[data-toggle="tooltip"] {
         text-decoration: underline;
       }
@@ -1004,14 +1026,79 @@
               <div style="overflow:auto">
                 <ul class="nav nav-tabs" id="consenter" role="tablist">
                   <li class="nav-item">
-                    <a class="nav-link active" id="consenter-consent-link" data-toggle="tab" href="#consenter-consent" role="tab" aria-controls="consenter-consent" aria-selected="true">Your Consent</a>
+                    <a class="nav-link active" id="consenter-correct-link" data-toggle="tab" href="#consenter-correct" role="tab" aria-controls="consenter-correct" aria-selected="true">Your Details</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link" id="consenter-consent-link" data-toggle="tab" href="#consenter-consent" role="tab" aria-controls="consenter-consent" aria-selected="true">Your Consent</a>
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" id="consenter-exhibit-link" data-toggle="tab" href="#consenter-exhibit" role="tab" aria-controls="consenter-exhibit" aria-selected="false">Your Exhibit Forms</a>
                   </li>
                 </ul>
+
+                <div class="tab-content" id="consenterCorrect">
+                  <div class="tab-pane fade show active" id="consenter-correct" role="tabpanel" aria-labelledby="consenter-correct-link" style="overflow:auto;">
+                    <h3 class="display-7 fw-bold">Your Details</h3>
+                    <div id="divConsenterCorrect" class="divSysAdminOption" style="width:100%">
+                      <div label="true">Full Name:</div>
+                      <div>
+                        <span id="consenter-correct-fullname">[Insert Username]</span>
+                      </div>
+                      <div label="true">Email Address:</div>
+                      <div>
+                        <span id="consenter-correct-email">[Insert Email]</span>
+                        <p>
+                          PLEASE NOTE: Corrections to your email address will trigger a signout from your account and an email sent to 
+                          your new email address with a temporary password. Login again with this password and you will be 
+                          prompted with a password reset screen. You may use your original password if you like.
+                        </p>
+                      </div>
+                      <div label="true">Cell Phone:</div>
+                      <div>
+                        <span id="consenter-correct-phone">[Insert Phone]</span>
+                      </div>
+                      <div label="true">&nbsp;</div>
+                      <div style="margin-top:30px;">
+                        <!-- Button trigger modal -->
+                        <button class="btn btn-primary btn-lg" data-bs-toggle="modal" data-bs-target="#correctBackdrop">EDIT</button>
+                        <!-- Modal -->
+                        <div class="modal fade" id="correctBackdrop" data-bs-backdrop="static" data-bs-keyboard="false" aria-labelledby="correctBackdropLabel" aria-hidden="true">
+                          <div class="modal-dialog  modal-dialog-scrollable">
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <h5 class="modal-title" id="correctBackdropLabel">Edit your account details</h5>
+                              </div>
+                              <div class="modal-body" style="text-align:left; overflow:auto;">
+                                <div style="clear:both; margin-top:10px;">First Name</div>
+                                <div><input type="text" class="form-control" id="txtConsentEditFirstName"></div>
+                                <div style="clear:both; margin-top:10px;">Middle Name</div>
+                                <div><input type="text" class="form-control" id="txtConsentEditMiddleName"></div>
+                                <div style="clear:both; margin-top:10px;">Last Name</div>
+                                <div><input type="text" class="form-control" id="txtConsentEditLastName"></div>
+                                <div style="clear:both; margin-top:10px;">Email Address</div>
+                                <div><input type="text" class="form-control" id="txtConsentEditEmail"></div>
+                                <div style="clear:both; margin-top:10px;">Cell Phone</div>
+                                <div><input type="text" class="form-control" id="txtConsentEditPhone"></div>
+                                <!--
+                                <div style="clear:both; margin-top:10px;">Please type your full name <span style="font-size: 10px;">(first, middle, last)</span> to digitally sign this Consent Form:</div>
+                                <div><input type="text" class="form-control" id="txtConsentEditSignature"></div>
+                                -->
+                              </div>
+                              <div class="modal-footer">
+                                <button id="btnConsenterCorrect" class="btn btn-primary" data-bs-dismiss="modal">SUBMIT CHANGES</button>
+                                &nbsp;
+                                <button class="btn btn-primary" data-bs-dismiss="modal">Cancel</button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
                 <div class="tab-content" id="consenterContent">
-                  <div class="tab-pane fade show active" id="consenter-consent" role="tabpanel" aria-labelledby="consenter-consent-link">
+                  <div class="tab-pane fade" id="consenter-consent" role="tabpanel" aria-labelledby="consenter-consent-link">
                     <h3 class="display-7 fw-bold">ETT Consent Form</h3>
                     <div id="divConsenterConsent" class="divSysAdminOption" style="overflow: auto; width:100%">
                       <p style="text-align: left;">
@@ -1139,38 +1226,6 @@
                           <div style="margin-right: 5px; float:left; text-align: center;">
                             To renew this Consent Form for another 10 years click<br>
                             <button id="btnRenewConsent" class="btn btn-primary" style="margin-top:6px;">RENEW</button>
-                          </div>                                                 
-                        </div>
-                        <div id="consentCorrect" style="width:215px; float:left; overflow: auto; vertical-align: middle; margin-right:4px; padding:10px; background-color: #e6e6ff;">
-                          <div style="margin-right: 5px; text-align: center;">
-                            To correct this Consent Form, click<br><br>
-                            <!-- Button trigger modal -->
-                            <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#correctBackdrop" style="margin-top:6px;">CORRECT</button>
-                            <!-- Modal -->
-                            <div class="modal fade" id="correctBackdrop" data-bs-backdrop="static" data-bs-keyboard="false" aria-labelledby="correctBackdropLabel" aria-hidden="true">
-                              <div class="modal-dialog  modal-dialog-scrollable">
-                                <div class="modal-content">
-                                  <div class="modal-header">
-                                    <h5 class="modal-title" id="correctBackdropLabel">Edit your Consent</h5>
-                                  </div>
-                                  <div class="modal-body" style="text-align:left; overflow:auto;">
-                                    <div style="clear:both; margin-top:10px;">Full Name <span style="font-size: 10px;">(first, middle, last)</span></div>
-                                    <div><input type="text" class="form-control" id="txtConsentEditFullname"></div>
-                                    <div style="clear:both; margin-top:10px;">Email Address</div>
-                                    <div><input type="text" class="form-control" id="txtConsentEditEmail"></div>
-                                    <div style="clear:both; margin-top:10px;">Cell Phone</div>
-                                    <div><input type="text" class="form-control" id="txtConsentEditPhone"></div>
-                                    <div style="clear:both; margin-top:10px;">Please type your full name <span style="font-size: 10px;">(first, middle, last)</span> to digitally sign this Consent Form:</div>
-                                    <div><input type="text" class="form-control" id="txtConsentEditSignature"></div>
-                                  </div>
-                                  <div class="modal-footer">
-                                    <button id="btnCorrectConsent" class="btn btn-primary" data-bs-dismiss="modal">CORRECT</button>
-                                    &nbsp;
-                                    <button class="btn btn-primary" data-bs-dismiss="modal">Cancel</button>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
                           </div>                                                 
                         </div>
                         <div id="consentSend"  style="width:215px; float:left; overflow: auto; vertical-align: middle; padding:10px; background-color: #e6e6ff;">
@@ -2229,7 +2284,7 @@
     /**
      * Perform a consent related api task
      */
-    const doConsentTask = async (task, parameters) => {
+    const doConsentTask = async (task, parameters, successCallback) => {
       const msg = document.getElementById('apiResponse');
       msg.innerHTML = '';
       try {
@@ -2286,7 +2341,7 @@
             if(rescindedDate.after(consentedDate) && rescindedDate.after(renewedDate)) {
               return 'rescinded';
             }
-            return task == 'correct-consent' ? 'corrected' : 'none';
+            return task == 'correct-consenter' ? 'corrected' : 'none';
           }
 
           const hide = id => document.getElementById(id).style.display = 'none';
@@ -2314,7 +2369,6 @@
             const color = lastAction == 'rescinded' ? 'red' : 'green';
             show('consentRescind');
             show('consentRenew');
-            show('consentCorrect');
             show('consentSend');
             if(document.location.pathname == '/consenter/exhibits/index.htm') {
               show('consenter-exhibit-link');
@@ -2357,7 +2411,6 @@
             case 'rescinded':
               showPostConsentFields(_lastAction);
               hide('consentRescind');
-              hide('consentCorrect');
               hide('consentSend');
               hide('consenter-exhibit-link');
               break;
@@ -2366,7 +2419,11 @@
               showPreConsentFields();
               break;
           }
-         }
+
+          if(successCallback) {
+            successCallback();
+          }
+        }
         else {
           msg.innerHTML = `<pre>${message}</pre>`;
         }
@@ -2417,16 +2474,21 @@
     }
 
     const setConsenter = () => {
-      const { consenter: { email, phone_number }, fullName } = consenterInfo ?? {};
+      const { consenter: { email, phone_number, firstname, lastname, middlename }, fullName } = consenterInfo ?? {};
       const role = AccessJwtCookie.getRole();
       const rolename = role.name ?? 'CONSENTING_PERSON';
       document.getElementById(`${rolename}_username`).innerHTML = fullName;
       document.getElementById('txtConsentFullname').value = fullName;
       document.getElementById('txtConsentEmail').value = email;
       document.getElementById('txtConsentPhone').value = phone_number;
-      document.getElementById('txtConsentEditFullname').value = fullName;
+      document.getElementById('txtConsentEditFirstName').value = firstname;
+      document.getElementById('txtConsentEditMiddleName').value = middlename;
+      document.getElementById('txtConsentEditLastName').value = lastname;
       document.getElementById('txtConsentEditEmail').value = email;
       document.getElementById('txtConsentEditPhone').value = phone_number;
+      document.getElementById('consenter-correct-fullname').innerHTML = fullName;
+      document.getElementById('consenter-correct-email').innerHTML = email;
+      document.getElementById('consenter-correct-phone').innerHTML = phone_number;
       populateEntityList();
       return consenterInfo;
     }
@@ -2489,13 +2551,27 @@
     /**
      * Submit corrections to the consenter consent form information. NOTE: Not implemented on the backend (pending client discussion)
      */
-    const correctConsent = async () => {
+    const correctConsenter = async () => {
       const { email } = IDJwtCookie.getUser() ?? {};
-      const alt_email = document.getElementById('txtConsentEditEmail').value;
-      const full_name = document.getElementById('txtConsentEditFullname').value;
+      const new_email = document.getElementById('txtConsentEditEmail').value;
+      const firstname = document.getElementById('txtConsentEditFirstName').value;
+      const middlename = document.getElementById('txtConsentEditMiddleName').value;
+      const lastname = document.getElementById('txtConsentEditLastName').value;
       const phone_number = document.getElementById('txtConsentEditPhone').value;
-      const signature = document.getElementById('txtConsentEditSignature').value;
-      await doConsentTask('correct-consent', { email, alt_email, full_name, phone_number, signature });
+      await doConsentTask(
+        'correct-consenter', 
+        { email, new_email, firstname, middlename, lastname, phone_number },
+        () => {
+          if(new_email != email) {
+            alert('Your account has been recreated.\n\nPlease check the inbox of your new email address for a temporary password.');
+            signOut();
+          }
+          else {
+            alert('Update complete');
+            location.reload();
+          }
+        }
+      );
     }
 
     /**
@@ -2633,6 +2709,9 @@
         ],
         consenter: {
           email: "roger@warnerbros.com",
+          firstname: 'Roger',
+          middlename: 'R',
+          lastname: 'Rabbit',
           phone_number: '+6174448888',
           active: 'Y',
           consented_timestamp: [ "2024-07-05T17:16:31.352Z" ],
@@ -3798,8 +3877,8 @@
       document.getElementById('btnSendConsent').addEventListener('click', () => {
         sendConsent();
       });
-      document.getElementById('btnCorrectConsent').addEventListener('click', () => {
-        correctConsent();
+      document.getElementById('btnConsenterCorrect').addEventListener('click', () => {
+        correctConsenter();
       });
       document.getElementById('txtExhibitSignature').addEventListener('keyup', () => {
         toggleHighlight(event.srcElement);

--- a/lib/Cognito.ts
+++ b/lib/Cognito.ts
@@ -170,6 +170,7 @@ export class CognitoConstruct extends Construct {
             statements: [new PolicyStatement({
               actions: [
                 'cognito-idp:ListUserPoolClients',
+                'cognito-idp:AdminUpdateUserAttributes',
               ],
               resources: ['*'],
               effect: Effect.ALLOW

--- a/lib/lambda/Utils.ts
+++ b/lib/lambda/Utils.ts
@@ -153,8 +153,12 @@ export const mergeResponses = (responses:LambdaProxyIntegrationResponse[]) => {
   return response;
 }
 
+export const isOkStatusCode = (code:any) => {
+  return /^2\d+/.test(`${code}`);
+}
+
 export const isOk = (response:LambdaProxyIntegrationResponse) => {
-  return /^2\d+/.test(`${response.statusCode}`);
+  return isOkStatusCode(response.statusCode);
 }
 
 /**
@@ -418,3 +422,13 @@ export const deepEqual = (obj1:any, obj2:any, parm?:'log.console'|'log.temp'|'al
 }
 
 export const deepClone = (obj:any) => JSON.parse(JSON.stringify(obj));
+
+/**
+ * Get the name of a property in a way that ensures string literals are refactored when changing the property name.
+ * Use like this: getPropertyName<MyType>("myPropertyName");
+ * @param property 
+ * @returns 
+ */
+export const getPropertyName = <T>(property: keyof T): string => {
+  return String(property);
+}

--- a/lib/lambda/_lib/cognito/UserAccount.ts
+++ b/lib/lambda/_lib/cognito/UserAccount.ts
@@ -1,0 +1,267 @@
+import { AdminCreateUserCommand, AdminCreateUserCommandOutput, AdminCreateUserRequest, AdminDeleteUserCommand, AdminDeleteUserCommandOutput, AdminDeleteUserRequest, AdminUpdateUserAttributesCommand, AdminUpdateUserAttributesCommandOutput, AdminUpdateUserAttributesRequest, AttributeType, CognitoIdentityProviderClient, UserType } from "@aws-sdk/client-cognito-identity-provider";
+import { StandardAttributes } from "aws-cdk-lib/aws-cognito";
+import { lookupUserPoolId } from "./Lookup";
+import { debugLog, log } from "../../Utils";
+import { IContext } from "../../../../contexts/IContext";
+import { Role, Roles } from "../dao/entity";
+
+export type CognitoAttributes = {
+  -readonly [K in keyof StandardAttributes]: Record<'propname'|'value', string|undefined>;
+}
+
+/**
+ * This class serves as a utility for performing CRUD operations against a user account in a cognito
+ * userpool.
+ */
+export class UserAccount {
+  private role:Role;
+  private region:string;
+  private UserPoolId:string;
+  private UserAttributes = [] as AttributeType[];
+  private message:string = 'ok';
+
+  /**
+   * Factory method for instances of this class. Can be used as the "read" CRUD operation as it 
+   * returns a UserAccount object corresponding to the email attribute provided.
+   * @param cognitoAttributes 
+   * @param role 
+   * @returns 
+   */
+  public static getInstance = async (cognitoAttributes:CognitoAttributes, role:Role):Promise<UserAccount> => {
+    const user = new UserAccount();
+
+    user.role = role;
+    user.UserAttributes.push(...UserAccount.getUserAttributes(cognitoAttributes));
+
+    // Get environment variables
+    user.region = process.env.REGION ?? 'us-east-2';
+    const prefix = process.env.PREFIX;
+
+    // Get the userpool ID
+    const userPoolName = `${prefix}-cognito-userpool`;
+
+    const id = await lookupUserPoolId(userPoolName, user.region);
+    if( ! id) {
+      throw new Error('Userpool ID lookup failed!');
+    }
+    user.UserPoolId = id;
+    return user;  
+  }
+
+  /**
+   * Transform a CognitoAttributes object into an AttributeType array.
+   * @param cognitoAttributes 
+   * @returns 
+   */
+  private static getUserAttributes = (cognitoAttributes:CognitoAttributes):AttributeType[] => {
+    const { email:emailAttr, phoneNumber:phoneAttr } = cognitoAttributes;
+    const userAttributes = [] as AttributeType[];
+    if(emailAttr) {
+      userAttributes.push({ Name:emailAttr.propname, Value:emailAttr.value });
+    }
+    if(phoneAttr) {
+      userAttributes.push({Name:phoneAttr.propname, Value:phoneAttr.value });
+    }
+    return userAttributes;    
+  }
+
+  /**
+   * Update the email and/or phone_number attributes of a user in the userpool. This requires that these
+   * attributes are configured to be mutable. Modification of the email address attribute will trigger an 
+   * automatic email to the new email address with a verification code and the email of the user will be
+   * switched to unverified (NOTE: since the user is already confirmed, and there is no way to demote a 
+   * user as unconfirmed using the SDK, the hosted UI verification prompt will not appear during a log
+   * in attempt, and unconventional workarounds with the preauthentication lambda trigger, flags, and
+   * redirects at the app dashboard screen would be necessary to make it work)
+   * @param cognitoAttributes 
+   */
+  public update = async (cognitoAttributes:CognitoAttributes):Promise<boolean> => {
+    const { UserPoolId, region, getEmail, logError } = this;
+    const { getUserAttributes } = UserAccount;
+
+    try {
+      const email = getEmail(); 
+      const AllAttributes = getUserAttributes(cognitoAttributes);
+      const UserAttributes = AllAttributes.filter(a => a.Name != 'email'); // Remove the email attribute
+      const client = new CognitoIdentityProviderClient({ region });
+      const input = { UserPoolId, Username: email, UserAttributes } as AdminUpdateUserAttributesRequest;
+      const command = new AdminUpdateUserAttributesCommand(input);
+
+      const response = await client.send(command) as AdminUpdateUserAttributesCommandOutput;
+      debugLog(response);
+      const code = response.$metadata.httpStatusCode ?? 200; // Assume ok if no code returned.
+      if( ! (code >= 200 && code < 300)) {
+        throw new Error(`Update of user in userpool failed, status code: ${code}`);
+      }
+      return true;
+    }
+    catch(e) {
+      logError(e as Error);
+      return false;
+    }
+  }
+
+  /**
+   * Swap out a user in a cognito userpool by deleting that user and replacing them with a new
+   * user whose attributes are provided. The user should receive an email at the new address
+   * with a temporary password and a link to the hosted UI to log in, which both confirms the user
+   * and verifies the new email in one shot.
+   * @param cognitoAttributes 
+   */
+  public replaceWith = async (cognitoAttributes:CognitoAttributes):Promise<UserType|undefined> => {
+    const { role, Delete, ok } = this;
+    const newUser = await UserAccount.getInstance(cognitoAttributes, role);
+    const user = await newUser.create(this) as UserType;
+    if( ! user) {
+      return;
+    }
+    await Delete();
+    return user;
+  }
+
+  /**
+   * Create the cognito user account
+   * @param userBeingReplaced 
+   * @returns 
+   */
+  public create = async (userBeingReplaced?:UserAccount):Promise<UserType|undefined> => {
+    const { UserPoolId, region, UserAttributes, role, getEmail, logError } = this;
+    let user:UserType|undefined = undefined;
+
+    try {
+      const Username = getEmail();
+      // Uncomment "SMS" if you want the welcome message to be sent to the sms number as well.
+      const DesiredDeliveryMediums = [
+        "EMAIL", 
+        // "SMS",
+      ];
+
+      const client = new CognitoIdentityProviderClient({ region });
+      // NOTE: role could be put in ValidationData, but this is available to the resignup trigger instead of ALL triggers.
+      const ClientMetadata = { role } as Record<string, string>
+
+      if(userBeingReplaced) {
+        ClientMetadata.old_email = `${userBeingReplaced.getEmail()}`;
+      }
+
+      const input = {
+        UserPoolId,
+        Username,
+        UserAttributes,
+        ForceAliasCreation: false,
+        // MessageAction: "RESEND", // Note: "RESEND" is a misnomer in this user creation context, and just means "SEND"
+        DesiredDeliveryMediums,        
+        ClientMetadata,
+      } as AdminCreateUserRequest;
+      const command = new AdminCreateUserCommand(input);
+
+      const response = await client.send(command) as AdminCreateUserCommandOutput;
+      console.log(`Created new cognito user account: ${JSON.stringify(response, null, 2)}`);
+      user = response.User;
+    }
+    catch(e) {
+      logError(e as Error);
+    }
+    finally {
+      return user;
+    }
+  }
+
+  /**
+   * Delete the cognito user account
+   */
+  public Delete = async ():Promise<boolean> => {
+    const { UserPoolId, region, getEmail, logError } = this;
+    try {
+      const Username = getEmail();
+      const client = new CognitoIdentityProviderClient({ region });
+      const input = {  UserPoolId, Username } as AdminDeleteUserRequest;
+      const command = new AdminDeleteUserCommand(input);
+      const response = await client.send(command) as AdminDeleteUserCommandOutput;
+      debugLog(response);
+      const code = response.$metadata.httpStatusCode ?? 200; // Assume ok if no code returned.
+      if( ! (code >= 200 && code < 300)) {
+        throw new Error(`Update of user in userpool failed, status code: ${code}`);
+      }
+      return true;
+    }
+    catch(e) {
+      logError(e as Error);
+      return false;
+    }
+  }
+    
+  private logError = (e:Error) => {
+    this.message = e.message;
+    log(e);
+  }
+
+  public getEmail = ():string|undefined => {
+    return this.UserAttributes.find(a => a.Name == 'email')?.Value;
+  }
+
+  public getRole = ():Role => {
+    return this.role;
+  }
+
+  public getMessage = ():string => {
+    return this.message
+  }
+
+  public ok = ():boolean => {
+    return this.message == 'ok';
+  }
+}
+
+
+
+
+/**
+ * RUN MANUALLY:
+ */
+const { argv:args } = process;
+if(args.length > 3 && args[2] == 'RUN_MANUALLY_COGNITO_USER_UPDATE') {
+
+  const task = args[3] as 'update' | 'replace';
+
+  (async () => {
+
+    // 1) Get context variables
+    const context:IContext = await require('../../../../contexts/context.json');
+    const { STACK_ID, REGION, TAGS: { Landscape }} = context;
+
+    // 2) Set the environment variables
+    process.env.REGION = REGION;
+    process.env.PREFIX = `${STACK_ID}-${Landscape}`;
+    process.env.DEBUG = 'true';
+
+    // 3) Configure the original and updated user parameters
+    const original = { email: { propname:'email', value:'cp1@warhen.work' } } as CognitoAttributes;
+    const updated = {
+      email: { propname:'email', value:'cp2@warhen.work' }, 
+      phoneNumber: { propname: 'phone_number', value: '+1234567890' }
+    } as CognitoAttributes
+
+    // 4) Execute the update or replacement
+    const user = await UserAccount.getInstance(original, Roles.CONSENTING_PERSON);
+    switch(task) {
+      case "update":
+        // Make the email address the same so as not to get updated itself.
+        updated.email!.value = original.email?.value;
+        await user.update(updated);
+        break;
+      case "replace":
+        await user.replaceWith(updated);
+        break;
+    }
+    
+    // 5) Report the results
+    if(user.ok()) {
+      console.log('Update complete.');
+    }
+    else {
+      console.log(user.getMessage());
+    }
+  })();
+
+}

--- a/lib/lambda/_lib/dao/dao-consenter.ts
+++ b/lib/lambda/_lib/dao/dao-consenter.ts
@@ -268,8 +268,8 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_DAO_CONSENTER') {
   const email = 'daffy@warnerbros.com';
   let consenter = { } as Consenter;
   let dao:DAOConsenter;
-  const execute = (task:any, taskname:string) => {
-    task()
+  const execute = (task:any, taskname:string, parms?:any) => {
+    task(parms)
       .then((retval:any) => {
         console.log(`${taskname} successful: ${JSON.stringify(retval, null, 2)}`);
       })
@@ -285,9 +285,11 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_DAO_CONSENTER') {
         middlename: 'D',
         lastname: 'Duck',
         title: 'Aquatic fowl',
+        consented_timestamp: [ '2024-10-03T20:26:53.762Z' ],
         phone_number: '617-333-5555',        
       } as Consenter);
-      execute(dao.create, task);
+      // execute(dao.create, task);
+      execute(dao.update, task, {} as Consenter);
       break;
     case TASK.update:
       enum UPDATE_TYPE { consent='consent', sub='sub', exhibit='exhibit' };

--- a/lib/lambda/_lib/timer/EggTimer.ts
+++ b/lib/lambda/_lib/timer/EggTimer.ts
@@ -12,8 +12,17 @@ export class EggTimer {
   private expirationDate:Date;
   private milliseconds:number;
 
-  public static getInstanceSetFor = (periods:number, periodType:PeriodType):EggTimer => {
-    const millisecondsNow = Date.now();
+  /**
+   * Factory method for getting an egg timer instance.
+   * @param periods 
+   * @param periodType 
+   * @param offsetDate Prior date that specifies a point in the past to indicate as the starting point of the 
+   * egg timer "countdown". This way the timer starts its "countdown" already partially elapsed. Useful if
+   * you want one egg timer instance to "take over" for another one.  
+   * @returns 
+   */
+  public static getInstanceSetFor = (periods:number, periodType:PeriodType, offsetDate?:Date):EggTimer => {
+    const millisecondsNow = offsetDate ? offsetDate.getTime() : Date.now();
     const millisecondsDelay = periods * periodType;
     const timer = new EggTimer(new Date(millisecondsNow + millisecondsDelay));
     timer.milliseconds = periods * periodType;

--- a/lib/lambda/functions/consenting-person/ConsentingPerson.ts
+++ b/lib/lambda/functions/consenting-person/ConsentingPerson.ts
@@ -433,6 +433,17 @@ export const saveExhibitData = async (email:string, exhibitForm:ExhibitForm): Pr
   await dao.update(oldConsenter, true); // NOTE: merge is set to true - means that other exhibit forms are retained.
 
   // Create a delayed execution to remove the exhibit form 2 days from now
+  await scheduleExhibitFormPurgeFromDatabase(newConsenter, exhibitForm);
+
+  return getConsenterResponse(email, true);
+};
+
+/**
+ * Create a delayed execution to remove an exhibit form at a point in the future determined by app configuration
+ * @param newConsenter 
+ * @param exhibitForm 
+ */
+export const scheduleExhibitFormPurgeFromDatabase = async (newConsenter:Consenter, exhibitForm:ExhibitForm) => {
   const envVarName = DelayedExecutions.ExhibitFormDbPurge.targetArnEnvVarName;
   const functionArn = process.env[envVarName];
   if(functionArn) {
@@ -447,9 +458,7 @@ export const saveExhibitData = async (email:string, exhibitForm:ExhibitForm): Pr
   else {
     console.error(`Cannot schedule exhibit form purge from database: ${envVarName} variable is missing from the environment!`);
   }
-
-  return getConsenterResponse(email, true);
-};
+}
 
 /**
  * Send full exhibit form to each authorized individual of the entity, remove it from the database, and save

--- a/lib/lambda/functions/consenting-person/ConsentingPerson.ts
+++ b/lib/lambda/functions/consenting-person/ConsentingPerson.ts
@@ -455,7 +455,7 @@ export const saveExhibitData = async (email:string, exhibitForm:ExhibitForm): Pr
  * @param newConsenter 
  * @param exhibitForm 
  */
-export const scheduleExhibitFormPurgeFromDatabase = async (newConsenter:Consenter, exhibitForm:ExhibitForm) => {
+export const scheduleExhibitFormPurgeFromDatabase = async (newConsenter:Consenter, exhibitForm:ExhibitForm, offsetDate?:Date) => {
   const envVarName = DelayedExecutions.ExhibitFormDbPurge.targetArnEnvVarName;
   const functionArn = process.env[envVarName];
   if(functionArn) {

--- a/lib/lambda/functions/consenting-person/Correction.ts
+++ b/lib/lambda/functions/consenting-person/Correction.ts
@@ -66,10 +66,10 @@ export class ConsentingPersonToCorrect {
         original.phoneNumber = { propname:'phone_number', value:phone_number};
         updated.phoneNumber = { propname:'phone_number', value:new_phone_number};
       }
-      else if( ! new_phone_number) {
+      else {
         // Have the new account inherit the old phone number 
-        updated.phoneNumber = { propname:'phone_number', value:phone_number}
-      }
+        updated.phoneNumber = { propname:'phone_number', value:phone_number, verified:true}
+       }
 
       const userAccount = await UserAccount.getInstance(original, Roles.CONSENTING_PERSON);
       if(newEmail()) {

--- a/lib/lambda/functions/consenting-person/Correction.ts
+++ b/lib/lambda/functions/consenting-person/Correction.ts
@@ -1,0 +1,193 @@
+import { UserType } from "@aws-sdk/client-cognito-identity-provider";
+import { IContext } from "../../../../contexts/IContext";
+import { CognitoAttributes, UserAccount } from "../../_lib/cognito/UserAccount";
+import { ReadParms } from "../../_lib/dao/dao";
+import { ConsenterCrud } from "../../_lib/dao/dao-consenter";
+import { Consenter, ConsenterFields, Roles, YN } from "../../_lib/dao/entity";
+import { scheduleExhibitFormPurgeFromDatabase } from "./ConsentingPerson";
+
+/**
+ * This class performs modifications to a consenting person that affect email and/or phone. In the case 
+ * of email, we are dealing with a primary key, so modification goes beyond editing the corresponding records 
+ * in place and must replace them instead - this applies to both the database and the userpool. Therefore,
+ * these items are removed/deactivated and replaced with new records. Edits to phone (but not email) must
+ * include the userpool, but records can be edited in place. Modifications that involve neither email or
+ * phone will only affect the corresponding database record as an update, and the userpool will be left alone.
+ */
+export class ConsentingPersonToCorrect {
+  private correctable:Consenter;
+  private lookup:boolean;
+  private message:string;
+
+  constructor(correctable:Consenter, lookup:boolean=true) {
+    this.correctable = correctable;
+    this.lookup = lookup;
+  }
+
+  public correct = async (correction:Consenter):Promise<boolean> => {
+    if(this.lookup) {
+      // The provided correctable consenter probably just has the key(s), so go to the database to get the rest.
+      // NOTE: Make sure the default timestamp conversion to date objects is avoided - The upcoming update needs them to be ISO strings.
+      const consenter = await ConsenterCrud(this.correctable).read({ convertDates:false } as ReadParms) as Consenter|null;
+      if( ! consenter) {
+        console.error(`Error: Lookup for consenter failed: ${JSON.stringify(this.correctable, null, 2)}`);
+        return false;
+      }
+      this.correctable = consenter;
+    }
+    
+    const { correctable, mergeConsenters } = this;
+    const { email, phone_number } = correctable;
+    const { email:new_email, phone_number:new_phone_number } = correction;
+
+    const newEmail = () => (new_email && new_email != email);
+    const newPhone = () => (new_phone_number && new_phone_number != phone_number);
+
+    // Possible cognito changes first:
+    if(newEmail() || newPhone()) {
+      /**
+       * Update the phone_number attributes of a user in the userpool. This requires that it is
+       * configured to be mutable.
+       * 
+       * and/or..
+       * 
+       * Create a new user account with the new email and delete the old user account.
+       * 
+       * NOTE: Modification of the email address attributes is not appropriate here (even if it was mutable)
+       * because this will trigger an automatic email to the new email address with a verification code and 
+       * the email of the user will be switched to unverified. Since the user is already confirmed, and there 
+       * is no way to demote a user as unconfirmed using the SDK, the hosted UI verification prompt will not 
+       * appear during a log in attempt, and unconventional workarounds with the preauthentication lambda 
+       * trigger, flags, and redirects at the app dashboard screen would be necessary to make it work)
+       */
+      const original = { email: { propname:'email', value:email } } as CognitoAttributes;
+      const updated = { email: { propname:'email', value:new_email } } as CognitoAttributes;
+      if(newPhone()) {
+        original.phoneNumber = { propname:'phone_number', value:phone_number};
+        updated.phoneNumber = { propname:'phone_number', value:new_phone_number};
+      }
+      else if( ! new_phone_number) {
+        // Have the new account inherit the old phone number 
+        updated.phoneNumber = { propname:'phone_number', value:phone_number}
+      }
+
+      const userAccount = await UserAccount.getInstance(original, Roles.CONSENTING_PERSON);
+      if(newEmail()) {
+        // Create a new user account in cognito and delete the old one.
+        const userType:UserType|undefined = await userAccount.replaceWith(updated);
+
+        // Obtain the sub value of the newly created user account.
+        const { Username:sub } = userType ?? {}
+        if( ! sub) {
+          let msg = userAccount.getMessage();
+          this.message = msg ? msg : `Error encountered while replacing ${email} with ${new_email}: ${msg}`;
+          return false;
+        }
+
+        // Carry over any fields from the old consenter that do not exist in the new consenter.
+        correction = mergeConsenters(correctable, correction);
+
+        // Give the new consenter the sub from the corresponding new cognito user account
+        correction.sub = sub;
+
+        // Add the new consenter to the database. NOTE: using update to create user to avoid validation checks.
+        await ConsenterCrud(correction).update({} as Consenter);
+
+        // Mark the old user as inactive in the database and blank out the sub and exhibit forms
+        correctable.active = YN.No;
+        correctable.exhibit_forms = [];
+        correctable.sub = 'DEFUNCT';
+        await ConsenterCrud(correctable).update();
+
+        // Duplicate any exhibit form expiration event bridge rules, but so as to apply against the new consenter db record.
+        const { exhibit_forms=[] } = correction;
+        if(exhibit_forms.length > 0) {
+          for(let i=0; i<exhibit_forms.length; i++) {
+            await scheduleExhibitFormPurgeFromDatabase(correction, exhibit_forms[i]);
+          }
+        }
+      }
+      else {        
+        // Update the existing cognito user account in place.
+        await userAccount.update(updated);
+        if( ! userAccount.ok()) {
+          this.message = userAccount.getMessage();
+          return false;
+        }
+
+        // Pass on any updates to the consenter to the corresponding database record.
+        await ConsenterCrud(correction).update(correctable);
+      }
+    }
+    else {
+      // Pass on any updates to the consenter to the corresponding database record.
+      await ConsenterCrud(correction).update(correctable);
+    }
+    
+    // TODO: What to do if the user has sent exhibit forms?
+    return true;
+  }
+
+  /**
+   * With the exception of the email field, apply all attributes from the source consenter to
+   * the corresponding attributes of the target consenter if those target attributes are not already set.
+   * @param source 
+   * @param target 
+   * @returns 
+   */
+  private mergeConsenters = (source:Consenter, target:Consenter):Consenter => {
+    let fld: keyof typeof ConsenterFields;
+    for(fld in ConsenterFields) {
+      if( ! source[fld]) continue;
+      switch(fld) {
+        case ConsenterFields.email:
+          continue;
+        default:
+          if( ! target[fld]) {
+            target[fld] = source[fld] as any;
+          }
+          break;
+      }
+    }
+    return target;
+  }
+  
+  public getMessage = () => {
+    return this.message;
+  }
+}
+
+
+
+
+
+/**
+ * RUN MANUALLY:
+ */
+const { argv:args } = process;
+if(args.length > 2 && args[2] == 'RUN_MANUALLY_CONSENTER_CORRECTION') {
+
+  (async () => {
+
+    // 1) Get context variables
+    const context:IContext = await require('../../../../contexts/context.json');
+    const { STACK_ID, REGION, TAGS: { Landscape }} = context;
+
+    // 2) Set the environment variables
+    process.env.REGION = REGION;
+    process.env.PREFIX = `${STACK_ID}-${Landscape}`;
+    process.env.DEBUG = 'true';
+
+    // 2) Execute the update
+    await new ConsentingPersonToCorrect({
+      email: 'cp1@warhen.work'
+    } as Consenter).correct({
+      email: 'cp2@warhen.work',
+      phone_number: '+0987654321',
+      middlename: 'Bartholomew'
+    } as Consenter);
+
+    console.log('Update complete.');
+  })();
+
+}

--- a/lib/role/ConsentingPerson.ts
+++ b/lib/role/ConsentingPerson.ts
@@ -96,10 +96,15 @@ export class LambdaFunction extends AbstractFunction {
           'EttConsentingPersonCognitoPolicy': new PolicyDocument({
             statements: [
               new PolicyStatement({
-                actions: [  'cognito-idp:List*'  ],
-                resources: [ '*' ],
+                actions: [ 'cognito-idp:*' ],
+                resources: [ userPoolArn ],
                 effect: Effect.ALLOW
-              })
+              }),
+              new PolicyStatement({
+                actions: [ 'cognito-idp:List*' ],
+                resources: ['*'],
+                effect: Effect.ALLOW
+              }),
             ]
           }),
           'EttConsentingPersonEventBridgePolicy': new PolicyDocument({


### PR DESCRIPTION
This feature adds the capability for a consenting individual to "correct" their account details:

- firstname
- middlename
- lastname
- email
- phone

Edits to name fields are trivial and affect the database only.
Edits to phone involve the database and also a modification to the corresponding cognito user account attribute.
Edits to email involve recreating the entire user in both the database and cognito, which involves a password reset.
NOTE: This feature DOES NOT include the emails to entity reps with a correction form attached - this to come in a follow-up feature