### PR TITLE
Consenter correction (2)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -157,7 +157,24 @@
         "${workspaceFolder}/lib/lambda/functions/consenting-person/BucketItemExhibitForms.ts",
         "RUN_MANUALLY_CONSENTER_EXHIBIT_FORMS",
         "us-east-2",
-        "correct"
+        "query"
+      ], 
+      "env": {
+        "AWS_PROFILE": "bu",
+        "REGION": "us-east-2"
+      }, 
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "BucketItemExhibitForms",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/functions/consenting-person/BucketItemCorrectionForm.ts",
+        "RUN_MANUALLY_CONSENTER_CORRECTION_FORM",
+        "us-east-2",
+        "add"
       ], 
       "env": {
         "AWS_PROFILE": "bu",
@@ -1065,6 +1082,21 @@
         "--runTestsByPath", 
         "-i", 
         "${workspaceFolder}/lib/lambda/functions/consenting-person/BucketInventory.test.ts" 
+      ],
+      "runtimeArgs": [ "--experimental-vm-modules" ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Consenter-Correction-Form",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+      "killBehavior": "forceful",
+      "args": [ 
+        "--runTestsByPath", 
+        "-i", 
+        "${workspaceFolder}/lib/lambda/functions/consenting-person/BucketCorrectionForm.test.ts" 
       ],
       "runtimeArgs": [ "--experimental-vm-modules" ],
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1058,6 +1058,21 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Jest Consenter-Bucket-Inventory",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+      "killBehavior": "forceful",
+      "args": [ 
+        "--runTestsByPath", 
+        "-i", 
+        "${workspaceFolder}/lib/lambda/functions/consenting-person/BucketInventory.test.ts" 
+      ],
+      "runtimeArgs": [ "--experimental-vm-modules" ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Jest PDF TextLine",
       "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
       "killBehavior": "forceful",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -427,6 +427,21 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "PDF send consenter correction form",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/functions/consenting-person/CorrectionFormEmail.ts",
+        "RUN_MANUALLY_SEND_CONSENTER_CORRECTION_FORM"
+      ],
+      "env": {
+        "AWS_PROFILE": "bu",
+        "REGION": "us-east-2"
+      },
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "PDF consent form page 1",
       "skipFiles": [ "<node_internals>/**" ],
       "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -365,7 +365,8 @@
       "args": [
         "${workspaceFolder}/lib/lambda/functions/delayed-execution/SendDisclosureRequestReminder.ts",
         "RUN_MANUALLY_SEND_DISCLOSURE_REQUEST_REMINDER",
-        "scheduled"
+        "existing",
+        "immediate"
       ], 
       "env": {
         "AWS_PROFILE": "bu",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -133,6 +133,23 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "BucketItemExhibitForm",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/functions/consenting-person/BucketItemExhibitForm.ts",
+        "RUN_MANUALLY_CONSENTER_EXHIBIT_FORM",
+        "us-east-2",
+        "correct"
+      ], 
+      "env": {
+        "AWS_PROFILE": "bu",
+        "REGION": "us-east-2"
+      }, 
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "BucketItemExhibitForms",
       "skipFiles": [ "<node_internals>/**" ],
       "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -607,6 +607,17 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "PDF Correction Form",
+      "skipFiles": [ "<node_internals>/**" ],
+      "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],
+      "args": [
+        "${workspaceFolder}/lib/lambda/_lib/pdf/CorrectionForm.ts",
+        "RUN_MANUALLY_CORRECTION_FORM"
+      ],
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "PDF TextLine",
       "skipFiles": [ "<node_internals>/**" ],
       "runtimeArgs": ["-r", "${workspaceFolder}/node_modules/ts-node/register/transpile-only"],

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -2401,6 +2401,7 @@
               html: task == 'register-consent' ? failureMsg: pendingMsg
             };
             hide('consenter-exhibit-compose-link');
+            hide('consenter-exhibit-amend-link');
             hide('consentOptions');
             show('consentFieldSet');
             fill(msg.id, msg.html);
@@ -2416,12 +2417,14 @@
             show('consentSend');
             if(document.location.pathname == '/consenter/exhibits/index.htm') {
               show('consenter-exhibit-compose-link');
+              show('consenter-exhibit-amend-link');
               populateExhibitFormSignoffFields();
               document.getElementById('waitForAI').style.display = 'none';
               document.getElementById('consenter-exhibit-compose-link').click();
             }
             else {
               hide('consenter-exhibit-compose-link');
+              hide('consenter-exhibit-amend-link');
               document.getElementById('waitForAI').style.display = 'inline';
             }
             show('consentOptions');
@@ -2433,6 +2436,7 @@
           // Hide all consent options
           hidePostConsentFields = () => {
             hide('consenter-exhibit-compose-link');
+            hide('consenter-exhibit-amend-link');
             hide('consentOptions');
             hide('consentFieldSet');
             fill('apiResponse', `${email} found to be deactivated (has not yet submitted consent)`);
@@ -2531,7 +2535,7 @@
       document.getElementById('txtConsentEmail').value = email;
       document.getElementById('txtConsentPhone').value = phone_number;
       document.getElementById('txtConsentEditFirstName').value = firstname;
-      document.getElementById('txtConsentEditMiddleName').value = middlename;
+      document.getElementById('txtConsentEditMiddleName').value = middlename ?? '';
       document.getElementById('txtConsentEditLastName').value = lastname;
       document.getElementById('txtConsentEditEmail').value = email;
       document.getElementById('txtConsentEditPhone').value = phone_number;
@@ -2607,6 +2611,14 @@
       const middlename = document.getElementById('txtConsentEditMiddleName').value;
       const lastname = document.getElementById('txtConsentEditLastName').value;
       const phone_number = document.getElementById('txtConsentEditPhone').value;
+
+      if( ! /^\+[1-9]\d{1,14}$/.test(phone_number)) {
+        alert(`"${phone_number}" is not a valid phone number\n` +
+          'Correct format: ^\+[1-9]\d{1,14}$'
+        );
+        return;
+      }
+      
       await doConsentTask(
         'correct-consenter', 
         { email, new_email, firstname, middlename, lastname, phone_number },

--- a/lib/lambda/Utils.ts
+++ b/lib/lambda/Utils.ts
@@ -110,22 +110,39 @@ export const errorResponse = (message:string, payload?:any): LambdaProxyIntegrat
   return response;
 }
 
-export const debugLog = (o:any) => {
+export const debugLog = (o:any, msg?:string) => {
   if(process.env.DEBUG == 'true') {
-    log(o);
+    log(o, msg);
   }
 }
 
-export const log = (o:any) => {
+const toConsole = (o:any, out:Function, msg?:string) => {
+  const output = (suffix:string) => {
+    if(msg) msg = msg.endsWith(': ') ? msg : `${msg}: `;
+    out(msg ? `${msg}${suffix}` : suffix);
+  }
   if(o instanceof Error) {
-    console.error(JSON.stringify(o, Object.getOwnPropertyNames(o), 2));
+    console.error(msg);
+    console.error(o);
     return;
   }
-  if(o instanceof Array) {
-    console.log(JSON.stringify(o, null, 2))
+  if(o instanceof Object) {
+    output(JSON.stringify(o, Object.getOwnPropertyNames(o), 2));
     return;
   }
-  console.log(o);
+  output(`${o}`);
+}
+
+export const log = (o:any, msg?:string) => {
+  toConsole(o, (s:string) => console.log(s), msg);
+}
+
+export const warn = (o:any, msg?:string) => {
+  toConsole(o, (s:string) => console.warn(s), msg);
+}
+
+export const error = (o:any, msg?:string) => {
+  toConsole(o, (s:string) => console.error(s), msg);
 }
 
 export const mergeResponses = (responses:LambdaProxyIntegrationResponse[]) => {

--- a/lib/lambda/Utils.ts
+++ b/lib/lambda/Utils.ts
@@ -421,6 +421,12 @@ export const deepEqual = (obj1:any, obj2:any, parm?:'log.console'|'log.temp'|'al
   return method1();
 }
 
+export const fieldsAreEqual = (fld1:any, fld2:any) => {
+  const compare1 = fld1 instanceof Date ? fld1.toISOString() : fld1;
+  const compare2 = fld2 instanceof Date ? fld2.toISOString() : fld2;
+  return compare1 == compare2;
+}
+
 export const deepClone = (obj:any) => JSON.parse(JSON.stringify(obj));
 
 /**

--- a/lib/lambda/_lib/BlankSheetOfPaper.ts
+++ b/lib/lambda/_lib/BlankSheetOfPaper.ts
@@ -8,6 +8,7 @@ import { lookupUserPoolId } from "./cognito/Lookup";
 import { ENTITY_WAITING_ROOM, EntityCrud } from "./dao/dao-entity";
 import { ConsenterFields, Entity, YN } from "./dao/entity";
 import { BucketToEmpty, DynamoDbTableToEmpty } from "./Emptier";
+import { log } from "../Utils";
 
 /**
  * --------------------------------------------------------
@@ -53,15 +54,15 @@ export const wipeClean = async (dryRun=true) => {
         const { sub: { S:Username }, email: { S:email }} = deletions[i];
         const input = { UserPoolId, Username } as AdminDeleteUserRequest;
         const command = new AdminDeleteUserCommand(input);
-        console.log(`${dryRun ? 'DRYRUN: ' : '' }Removing consenter from userpool: ${JSON.stringify(input, null, 2)}`);
+        log(input, `${dryRun ? 'DRYRUN: ' : '' }Removing consenter from userpool`);
         if(dryRun) {
           return new Promise((resolve) => resolve('dryrun'));
         }
         const output = await cognitoClient.send(command) as AdminDeleteUserCommandOutput;
-        console.log(`User ${email} deleted: ${JSON.stringify(output, null, 2)}`);
+        log(output, `User ${email} deleted`);
       }
       catch(reason) {
-        console.log(JSON.stringify(reason, Object.getOwnPropertyNames(reason), 2));
+        log(reason);
       }
     }
   }

--- a/lib/lambda/_lib/EmailWithAttachments.ts
+++ b/lib/lambda/_lib/EmailWithAttachments.ts
@@ -1,6 +1,6 @@
 import { SESv2Client, SendEmailCommand, SendEmailCommandInput, SendEmailResponse } from "@aws-sdk/client-sesv2";
 import { IPdfForm } from "../_lib/pdf/PdfForm";
-import { bytesToBase64 } from "../Utils";
+import { bytesToBase64, error, log } from "../Utils";
 import { v4 as uuidv4 } from 'uuid';
 
 export type Attachment = { pdf:IPdfForm, name:string, description:string }
@@ -12,9 +12,7 @@ export const sendEmail = async (parms:EmailParms):Promise<boolean> => {
   
   const { subject, to, cc=[], bcc=[], message, from, attachments } = parms;
 
-  console.log(`Sending email: ${JSON.stringify({
-    subject, to, cc, bcc, from
-  }, null, 2)}`);
+  log({ subject, to, cc, bcc, from }, 'Sending email');
 
   const mainBoundary = uuidv4();
   const mainBoundaryStart=`--${mainBoundary}`;
@@ -95,7 +93,7 @@ ${mainBoundaryEnd}
     messageId = response?.MessageId;
   } 
   catch (e:any) {
-    console.log(e);
+    error(e);
     return false;
   }
   return messageId ? true : false;

--- a/lib/lambda/_lib/EmailWithAttachments.ts
+++ b/lib/lambda/_lib/EmailWithAttachments.ts
@@ -12,6 +12,10 @@ export const sendEmail = async (parms:EmailParms):Promise<boolean> => {
   
   const { subject, to, cc=[], bcc=[], message, from, attachments } = parms;
 
+  console.log(`Sending email: ${JSON.stringify({
+    subject, to, cc, bcc, from
+  }, null, 2)}`);
+
   const mainBoundary = uuidv4();
   const mainBoundaryStart=`--${mainBoundary}`;
   const mainBoundaryEnd=`${mainBoundaryStart}--`;

--- a/lib/lambda/_lib/Emptier.ts
+++ b/lib/lambda/_lib/Emptier.ts
@@ -1,6 +1,7 @@
 import { AttributeValue, BatchWriteItemCommand, BatchWriteItemCommandInput, DynamoDBClient, ScanCommand, ScanCommandInput, ScanCommandOutput, WriteRequest } from "@aws-sdk/client-dynamodb";
 import { DeleteObjectsCommand, ListObjectsV2Command, ListObjectsV2CommandOutput, S3Client } from "@aws-sdk/client-s3";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { log } from "../Utils";
 
 /**
  * Simple s3 bucket emptier. Run against any bucket with non-versioned content.
@@ -40,14 +41,14 @@ export class BucketToEmpty {
 
       if (objectsToDelete && objectsToDelete.length > 0) {
         if(dryRun) {
-          console.log(`DRYRUN: Deleting ${JSON.stringify(objectsToDelete, null, 2)} from ${Bucket}`);
+          log(objectsToDelete, `DRYRUN - Deleting the following objects from ${Bucket}`)
         }
         else {
           // Delete the objects in batches
           await s3Client.send(new DeleteObjectsCommand({
             Bucket, Delete: { Objects: objectsToDelete },
           }));
-          console.log(`Deleted ${JSON.stringify(objectsToDelete, null, 2)} from ${Bucket}`);
+          log(objectsToDelete, `Deleted the following from ${Bucket}`)
         }
         total += objectsToDelete.length;
       }
@@ -122,12 +123,11 @@ export class DynamoDbTableToEmpty {
           }
         } as BatchWriteItemCommandInput;
 
-        const msg = `Deleting: ${JSON.stringify(batchWriteParams, null, 2)}`;
         if(dryRun) {
-          console.log(`DRYRUN: ${msg}`);
+          console.log(batchWriteParams, `DRYRUN: Deleting`);
           continue;
         }
-        console.log(msg);
+        console.log(batchWriteParams, 'Deleting');
         await docClient.send(new BatchWriteItemCommand(batchWriteParams));
       }
 

--- a/lib/lambda/_lib/cognito/Lookup.ts
+++ b/lib/lambda/_lib/cognito/Lookup.ts
@@ -16,6 +16,7 @@ import {
   AdminDeleteUserCommandOutput
 } from '@aws-sdk/client-cognito-identity-provider';
 import { Role, Roles } from '../dao/entity';
+import { error } from '../../Utils';
 
 /**
  * A cognito post signup confirmation event will indicate a specific user pool client ID. This client needs to
@@ -57,7 +58,7 @@ export const lookupRole = async (userPoolId:string, clientId:string, region:stri
     return role;
   }
   catch(e) {
-    console.log(e);
+    error(e);
     return;
   }
 }

--- a/lib/lambda/_lib/cognito/UserAccount.ts
+++ b/lib/lambda/_lib/cognito/UserAccount.ts
@@ -168,7 +168,7 @@ export class UserAccount {
       const command = new AdminCreateUserCommand(input);
 
       const response = await client.send(command) as AdminCreateUserCommandOutput;
-      console.log(`Created new cognito user account: ${JSON.stringify(response, null, 2)}`);
+      log(response, 'Created new cognito user account');
       user = response.User;
     }
     catch(e) {

--- a/lib/lambda/_lib/config/Config.ts
+++ b/lib/lambda/_lib/config/Config.ts
@@ -1,4 +1,5 @@
 import { CONFIG } from "../../../../contexts/IContext";
+import { log } from "../../Utils";
 import { DAOConfig, DAOFactory } from "../dao/dao";
 import { ConfigBatch } from "../dao/dao-config";
 import { Config, ConfigName, ConfigNames, ConfigType, ConfigTypes } from "../dao/entity";
@@ -76,7 +77,7 @@ export class Configurations {
       let dbOutput = await getDbConfig() as Config[];
       dbOutput = dbOutput ?? [];
       if(dbOutput.length == 0) {
-        console.log('Pre-populating database configurations...');
+        log('Pre-populating database configurations...');
         // Pre-populate the table - this must be the first time it is being accessed after having been cloudformed.
         await this.setDbConfigs();
       }
@@ -106,7 +107,7 @@ export class Configurations {
         let dbOutput = await getDbConfig() as Config[];
         dbOutput = dbOutput ?? [];
         if(dbOutput.length == 0) {
-          console.log('Pre-populating database configurations...');
+          log('Pre-populating database configurations...');
           // Pre-populate the table - this must be the first time it is being accessed after having been cloudformed.
           await this.setDbConfigs();
         }
@@ -159,31 +160,31 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_CONFIG') {
     const ctx = await import('../../../../contexts/context.json');
     ctx.CONFIG.useDatabase = false;
 
-    console.log("Test configurations from an object:")
+    log("Test configurations from an object:")
     let configs = new Configurations(ctx.CONFIG as CONFIG);
     let appConfigs = await configs.getAppConfigs();
-    console.log(JSON.stringify(appConfigs));
+    log(appConfigs);
     let appConfig = await configs.getAppConfig(ConfigNames.CONSENT_EXPIRATION);
-    console.log(JSON.stringify(appConfig));
+    log(appConfig);
 
-    console.log("\nTest configurations from an environment variable:")
+    log("\nTest configurations from an environment variable:")
     process.env[Configurations.ENV_VAR_NAME] = JSON.stringify(ctx.CONFIG);
     configs = new Configurations();
     appConfigs = await configs.getAppConfigs();
-    console.log(JSON.stringify(appConfigs));
+    log(appConfigs);
     appConfig = await configs.getAppConfig(ConfigNames.CONSENT_EXPIRATION);
-    console.log(JSON.stringify(appConfig));
+    log(appConfig);
 
-    console.log("\nSaving config to database...");
+    log("\nSaving config to database...");
     await configs.setDbConfigs();
 
-    console.log("\nTest configurations from database lookup:")
+    log("\nTest configurations from database lookup:")
     ctx.CONFIG.useDatabase = true;
     configs = new Configurations(ctx.CONFIG as CONFIG);
     appConfigs = await configs.getAppConfigs();
-    console.log(JSON.stringify(appConfigs));
+    log(appConfigs);
     appConfig = await configs.getAppConfig(ConfigNames.CONSENT_EXPIRATION);
-    console.log(JSON.stringify(appConfig));
+    log(appConfig);
 
   })();
 }

--- a/lib/lambda/_lib/dao/dao-consenter.ts
+++ b/lib/lambda/_lib/dao/dao-consenter.ts
@@ -1,7 +1,7 @@
 import { DeleteItemCommand, DeleteItemCommandInput, DeleteItemCommandOutput, DynamoDBClient, GetItemCommand, GetItemCommandInput, GetItemCommandOutput, QueryCommand, QueryCommandInput, TransactWriteItem, TransactWriteItemsCommand, TransactWriteItemsCommandInput, UpdateItemCommand, UpdateItemCommandInput, UpdateItemCommandOutput } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { DynamoDbConstruct, IndexBaseNames, TableBaseNames } from "../../../DynamoDb";
-import { deepClone } from "../../Utils";
+import { deepClone, log } from "../../Utils";
 import { DAOConsenter, ReadParms } from "./dao";
 import { convertFromApiObject } from "./db-object-builder";
 import { Builder, MergeParms } from "./db-update-builder-utils";
@@ -188,7 +188,7 @@ export function ConsenterCrud(consenterInfo:Consenter, _dryRun:boolean=false): D
    */
   const transUpdate = async (inputs:UpdateItemCommandInput[]) => {
     if(inputs.length == 0) {
-      console.log(`Consenter update cancelled: No changes detected in: ${JSON.stringify(consenterInfo, null, 2)}`);
+      log(consenterInfo, `Consenter update cancelled: No changes detected in`);
       return;
     }
     const TransactItems = [] as TransactWriteItem[];
@@ -271,7 +271,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_DAO_CONSENTER') {
   const execute = (task:any, taskname:string, parms?:any) => {
     task(parms)
       .then((retval:any) => {
-        console.log(`${taskname} successful: ${JSON.stringify(retval, null, 2)}`);
+        log(retval, `${taskname} successful`);
       })
       .catch((e:any) => {
         JSON.stringify(e, Object.getOwnPropertyNames(e), 2);

--- a/lib/lambda/_lib/dao/dao-invitation.ts
+++ b/lib/lambda/_lib/dao/dao-invitation.ts
@@ -5,7 +5,7 @@ import { convertFromApiObject } from './db-object-builder';
 import { invitationUpdate } from './db-update-builder.invitation';
 import { Invitation, InvitationFields } from './entity';
 import { DynamoDbConstruct, IndexBaseNames, TableBaseNames } from '../../../DynamoDb';
-import { debugLog } from '../../Utils';
+import { debugLog, log } from '../../Utils';
 
 /**
  * Basic CRUD operations for the invitations table.
@@ -159,7 +159,7 @@ export function InvitationCrud(invitationInfo:Invitation, _dryRun:boolean=false)
       throw new Error(`User update error: No fields to update for ${_code}`);
     }
     
-    console.log(`Updating existing invitation to: ${JSON.stringify({ invitation_code:_code, entity_id }, null, 2)}`);
+    log({ invitation_code:_code, entity_id }, `Updating existing invitation to`);
     const input = invitationUpdate(TableName, invitationInfo).buildUpdateItemCommandInput() as UpdateItemCommandInput;
     command = new UpdateItemCommand(input);
     debugLog(command);

--- a/lib/lambda/_lib/dao/db-object-builder.test.ts
+++ b/lib/lambda/_lib/dao/db-object-builder.test.ts
@@ -1,3 +1,4 @@
+import { log } from '../../Utils';
 import { ConvertObjectFilter, convertToApiObject, convertFromApiObject } from './db-object-builder';
 
 const bigInput = {
@@ -174,7 +175,7 @@ if(jestTest) {
 
     it('Should output expected result for array root object', () => {
       let output = convertToApiObject([ bigInput, bigInput ]);
-      console.log(JSON.stringify(output, null, 2));
+      log(output);
       expect(output).toEqual({
         L: [ { M: expectedBigOutput }, { M: expectedBigOutput } ]
       })
@@ -254,13 +255,13 @@ else {
 
   switch(task) {
     case 'convert':
-      console.log(JSON.stringify(convertToApiObject(bigInput), null, 2));
+      log(convertToApiObject(bigInput));
       break;
     case 'restore':
-      console.log(JSON.stringify(convertFromApiObject(expectedBigOutput), null, 2));
+      log(convertFromApiObject(expectedBigOutput));
       break;
     default:
-      console.log('Insufficient parameters: failed to specify "convert" or "restore"');
+      log('Insufficient parameters: failed to specify "convert" or "restore"');
       break;
   }
   

--- a/lib/lambda/_lib/dao/db-update-builder.consenter.test.ts
+++ b/lib/lambda/_lib/dao/db-update-builder.consenter.test.ts
@@ -172,14 +172,16 @@ describe('getCommandInputBuilderForConsenterUpdate', () => {
         ["#sub"]: sub,
         ["#title"]: title,
         ["#update_timestamp"]: update_timestamp,
+        ["#exhibit_forms"]: "exhibit_forms",
       },
       ExpressionAttributeValues: {
         [":sub"]: { "S": newConsenter.sub },
         [":title"]: { "S": newConsenter.title },
         [":update_timestamp"]: { "S": isoString },
+        [":exhibit_forms"]: { "L": [] },
       },
       // NOTE: fields will be set in the same order as they appear in the entity.ConsenterFields
-      UpdateExpression: `SET #sub = :sub, #title = :title, #update_timestamp = :update_timestamp`
+      UpdateExpression: `SET #sub = :sub, #title = :title, #update_timestamp = :update_timestamp, #exhibit_forms = :exhibit_forms`
     } as UpdateItemCommandInput;
 
     expect(deepEquivalent(input, expectedOutput)).toBe(true);

--- a/lib/lambda/_lib/dao/db-update-builder.consenter.ts
+++ b/lib/lambda/_lib/dao/db-update-builder.consenter.ts
@@ -1,5 +1,5 @@
 import { AttributeValue, UpdateItemCommandInput } from "@aws-sdk/client-dynamodb";
-import { deepClone, deepEqual } from '../../Utils';
+import { deepClone, deepEqual, fieldsAreEqual } from '../../Utils';
 import { convertToApiObject, wrap } from './db-object-builder';
 import { Builder, getBlankCommandInput, getFldSetStatement, MergeParms } from "./db-update-builder-utils";
 import { Consenter, ConsenterFields, ExhibitForm } from "./entity";
@@ -70,7 +70,7 @@ export const consenterUpdate = (TableName:string, _new:Consenter, old:Consenter=
 
         default:
           if( ! _new[fld]) continue;
-          if(_new[fld] != old[fld]) { // Add to expressions only if the field has changed in value.
+          if( ! fieldsAreEqual(_new[fld], old[fld])) { // Add to expressions only if the field has changed in value.
             input.ExpressionAttributeNames![`#${fld}`] = fld;
             input.ExpressionAttributeValues![`:${fld}`] = wrap(_new[fld]);
             updates.push({ [`#${fld}`]: `:${fld}`});

--- a/lib/lambda/_lib/invitation/Invitation.ts
+++ b/lib/lambda/_lib/invitation/Invitation.ts
@@ -3,6 +3,7 @@ import { DAOInvitation, DAOFactory } from '../dao/dao';
 import { SESv2Client, SendEmailCommand, SendEmailCommandInput, SendEmailResponse } from '@aws-sdk/client-sesv2';
 import { v4 as uuidv4 } from 'uuid';
 import { ENTITY_WAITING_ROOM } from '../dao/dao-entity';
+import { error } from '../../Utils';
 
 /**
  * An invitation email is one sent with a link in it to the ETT privacy policy acknowledgement webpage as the
@@ -141,7 +142,7 @@ export class UserInvitation {
       }
     } 
     catch (e:any) {
-      console.log(e);
+      error(e);
       return false;
     }
     return this.messageId ? true : false;
@@ -185,7 +186,7 @@ export class UserInvitation {
       return await dao.create();
     }
     catch (e:any) {
-      console.log(e);
+      error(e);
       return null;      
     }
   }

--- a/lib/lambda/_lib/invitation/Registration.ts
+++ b/lib/lambda/_lib/invitation/Registration.ts
@@ -1,3 +1,4 @@
+import { error } from "../../Utils";
 import { DAOFactory, DAOInvitation } from "../dao/dao";
 import { Entity, Invitation, InvitationFields } from "../dao/entity";
 
@@ -48,7 +49,7 @@ export class Registration {
       return true;
     }
     catch (e:any) {
-      console.log(e);
+      error(e);
       return false;      
     }
   }
@@ -77,7 +78,7 @@ export class Registration {
       return true;
     }
     catch (e:any) {
-      console.log(e);
+      error(e);
       return false;      
     }
   }  

--- a/lib/lambda/_lib/invitation/SignupLink.ts
+++ b/lib/lambda/_lib/invitation/SignupLink.ts
@@ -1,4 +1,5 @@
 import { Actions } from '../../../role/AbstractRole';
+import { error } from '../../Utils';
 import { lookupUserPoolClientId, lookupUserPoolId } from '../cognito/Lookup';
 import { Role } from "../dao/entity";
 
@@ -74,7 +75,7 @@ export class SignupLink {
       return signUpUrl;  
     } 
     catch (e) {
-      console.log(e);
+      error(e);
       return undefined;
     }  
   }

--- a/lib/lambda/_lib/pdf/CorrectionForm.ts
+++ b/lib/lambda/_lib/pdf/CorrectionForm.ts
@@ -1,0 +1,190 @@
+import { Color, PDFDocument, PDFFont, PDFPage, PDFPageDrawTextOptions, rgb, StandardFonts } from "pdf-lib";
+import { Consenter, ConsenterFields } from "../dao/entity";
+import { IPdfForm, PdfForm } from "./PdfForm";
+import { EmbeddedFonts } from "./lib/EmbeddedFonts";
+import { Align, Margins, rgbPercent, VAlign } from "./lib/Utils";
+import { writeFile } from "fs/promises";
+import { Page } from "./lib/Page";
+import { CellDef, Format, Table, TableDef } from "./lib/Table";
+
+const blue = rgbPercent(47, 84, 150) as Color;
+const white = rgb(1, 1, 1) as Color;
+const red = rgbPercent(255, 0, 0);
+
+
+export class CorrectionForm extends PdfForm implements IPdfForm {
+  private oldConsenter:Consenter;
+  private newConsenter:Consenter;
+  font:PDFFont;
+  boldfont:PDFFont;
+
+  constructor(oldConsenter:Consenter, newConsenter:Consenter) {
+    super();
+    this.oldConsenter = oldConsenter;
+    this.newConsenter = newConsenter;
+    this.pageMargins = { top: 35, bottom: 35, left: 50, right: 40 } as Margins;
+  }
+
+  /**
+   * @returns The bytes for the entire pdf form.
+   */
+  public async getBytes():Promise<Uint8Array> {
+    const {drawTitle, drawIntro, drawLogo, drawBody } = this;
+
+    this.doc = await PDFDocument.create();
+    this.embeddedFonts = new EmbeddedFonts(this.doc);
+    this.boldfont = await this.embeddedFonts.getFont(StandardFonts.HelveticaBold);
+    this.font = await this.embeddedFonts.getFont(StandardFonts.Helvetica);
+    this.form = this.doc.getForm();
+    
+    const { doc, form, embeddedFonts, pageMargins } = this;
+    
+    this.page = new Page(doc.addPage([620, 785]) as PDFPage, pageMargins, embeddedFonts);
+
+    await drawLogo(this.page);
+
+    await drawTitle();
+
+    await drawIntro();
+
+    await drawBody();
+
+    const pdfBytes = await doc.save();
+    return pdfBytes;
+  }
+  
+
+  /**
+   * Draw the title and subtitle
+   */
+  private drawTitle = async () => {
+    const { boldfont, font, page } = this;
+    await page.drawCenteredText('ETHICAL TRANSPARENCY TOOL (ETT)', { size: 12, font:boldfont }, 4);
+    await page.drawCenteredText('Consenting Individual Correction Form', { size:10, font }, 8);
+  }
+
+  
+  /**
+   * Draw the introductory language
+   */
+  private drawIntro = async () => {
+    const { font, boldfont, page, _return } = this;
+    const size = 10;
+
+    _return(8);
+    await page.drawWrappedText({
+      text: `The following consenting individual has made corrections to their name and/or contact information.`,
+      options: { size, font },
+      linePad: 4, 
+      padBottom: 8
+    });
+
+    const print = (segment:string, options:PDFPageDrawTextOptions) => {
+      const { font, size } = options;
+      page.basePage.drawText(segment, options);
+      const lastPrintedWidth = font!.widthOfTextAtSize(segment, size!);
+      page.basePage.moveRight(lastPrintedWidth);  
+    }
+
+    // Print variably formatted items on the same line.
+    print('The corrected items are ', { font, size });
+    print('highlighted ', { color:red, font:boldfont, size:12 });
+    print('below.', { font, size });
+  }
+
+  private drawBody = async () => {
+    const { font, boldfont, _return, newConsenter:n, oldConsenter:o } = this;
+    _return(50);
+
+    const { firstname, middlename, lastname, email, phone_number } = ConsenterFields;
+    const getFont = (fldname:ConsenterFields) => o[fldname] == n[fldname] ? font : boldfont;
+    const getColor = (fldname:ConsenterFields) => o[fldname] == n[fldname] ? undefined : red;
+
+    await new Table(this, 
+      {
+        borderColor: blue, borderWidth: 1, font, 
+        format: { align: Align.left, valign: VAlign.middle, margins: { left:8 } } as Format,
+        rows: [
+          {
+            height: 30, font:boldfont, backgroundColor:blue, color:white, size:12, cells: [
+              { width: 100, text: 'Item', format: { align: Align.center }} as CellDef,
+              { text: 'Prior', format: { align: Align.center }} as CellDef,
+              { text: 'Corrected', format: { align: Align.center }} as CellDef,
+            ]
+          },
+          {
+            height: 30, borderColor:blue, size:12, cells: [
+              { width: 100, text: 'First Name', format: { align: Align.right, margins: { right:8 } } },
+              { text: o.firstname },
+              { text: n.firstname, font:getFont(firstname), color:getColor(firstname) },
+            ]
+          },
+          {
+            height: 30, borderColor:blue, size:12, cells: [
+              { width: 100, text: 'Middle Name', format: { align: Align.right, margins: { right:8 } } },
+              { text: o.middlename },
+              { text: n.middlename, font:getFont(middlename), color:getColor(middlename) },
+            ]
+          },
+          {
+            height: 30, borderColor:blue, size:12, cells: [
+              { width: 100, text: 'Last Name', format: { align: Align.right, margins: { right:8 } } },
+              { text: o.lastname },
+              { text: n.lastname, font:getFont(lastname), color:getColor(lastname) },
+            ]
+          },
+          {
+            height: 30, borderColor:blue, size:12, cells: [
+              { width: 100, text: 'Email Address', format: { align: Align.right, margins: { right:8 } } },
+              { text: o.email },
+              { text: n.email, font:getFont(email), color:getColor(email) },
+            ]
+          },
+          {
+            height: 30, borderColor:blue, size:12, cells: [
+              { width: 100, text: 'Cell Phone', format: { align: Align.right, margins: { right:8 } } },
+              { text: o.phone_number },
+              { text: n.phone_number, font:getFont(phone_number), color:getColor(phone_number) },
+            ]
+          },
+        ]
+      } as TableDef
+    ).draw();
+  }
+
+  public async writeToDisk(path:string) {
+    writeFile(path, await this.getBytes());
+  }
+
+}
+
+
+
+
+
+const { argv:args } = process;
+if(args.length > 2 && args[2] == 'RUN_MANUALLY_CORRECTION_FORM') {
+
+  const oldConsenter = {
+    email: 'bugs@warnerbros.com',
+    firstname: 'Bugs',
+    middlename: 'Bartholomew',
+    lastname: 'Bunny',
+    phone_number: '+1234567890',
+    active: 'Y'
+  } as Consenter;
+
+  const newConsenter = {
+    email: 'bugs@warnerbros.com',
+    firstname: 'Bugs',
+    middlename: 'Cornelius',
+    lastname: 'Bunny',
+    phone_number: '+1234567890',
+    active: 'Y'
+  } as Consenter;
+
+  (async () => {
+    await new CorrectionForm(oldConsenter, newConsenter).writeToDisk('./lib/lambda/_lib/pdf/CorrectionForm.pdf');
+    
+  })();
+}

--- a/lib/lambda/_lib/pdf/ExhibitFormFull.ts
+++ b/lib/lambda/_lib/pdf/ExhibitFormFull.ts
@@ -6,6 +6,7 @@ import { IPdfForm, PdfForm } from './PdfForm';
 import { Page } from './lib/Page';
 import { Rectangle } from './lib/Rectangle';
 import { Align, Margins, VAlign } from './lib/Utils';
+import { log } from '../../Utils';
 
 /**
  * This class represents an exhibit pdf form that can be dynamically generated around the provided exhibit data.
@@ -141,7 +142,7 @@ export class ExhibitFormFull extends PdfForm implements IPdfForm {
   public async readFromDisk(path:string) {
     const buf:Buffer = await readFile(path);
     const pdf = await PDFDocument.load(buf) as PDFDocument;
-    console.log(JSON.stringify(pdf.catalog, Object.getOwnPropertyNames(pdf.catalog), 2));
+    log(pdf.catalog);
   }
 }
 

--- a/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
+++ b/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
@@ -120,16 +120,15 @@ export const demolishEntity = async (entity_id:string, notify:boolean, dryRun?:b
     for(var i=0; i<emailAddresses.length; i++) {
       var email = emailAddresses[i];
       try {
-        console.log(`Sending email to ${email}`);
+        log(`Sending email to ${email}`);
         if(dryRun) {
           continue;
         }
         await notifyUserOfDemolition(email, entityToDemolish.entity);
-        console.log('Email sent');
+        log('Email sent');
       }
       catch(reason) {
-        console.error(`Error sending email to ${email}`);
-        console.log(JSON.stringify(reason, Object.getOwnPropertyNames(reason), 2));
+        log(reason, `Error sending email to ${email}`);
       }
     }
   }
@@ -143,7 +142,7 @@ export const demolishEntity = async (entity_id:string, notify:boolean, dryRun?:b
  * @returns LambdaProxyIntegrationResponse
  */
 export const notifyUserOfDemolition = async (emailAddress:string, entity:Entity):Promise<void> => {
-  console.log(`Notifying ${emailAddress} that entity ${entity.entity_id}: ${entity.entity_name} was demolished`);
+  log(`Notifying ${emailAddress} that entity ${entity.entity_id}: ${entity.entity_name} was demolished`);
 
   const FromEmailAddress = await getSysAdminEmail();
 
@@ -195,7 +194,7 @@ export const notifyUserOfDemolition = async (emailAddress:string, entity:Entity)
     console.error(`No message ID in SendEmailResponse for ${emailAddress}`);
   }
   if(response) {
-    console.log(JSON.stringify(response, null, 2));
+    log(response);
   }
 }
 
@@ -401,7 +400,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_AUTH_IND') {
 
     switch(task as Task) {
       case Task.LOOKUP_USER_CONTEXT:
-        console.log('NOT IMPLEMENTED');
+        log('NOT IMPLEMENTED');
         break;
 
       case Task.DEMOLISH_ENTITY:
@@ -438,20 +437,20 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_AUTH_IND') {
         break;
 
       case Task.PING:
-        console.log('NOT IMPLEMENTED');
+        log('NOT IMPLEMENTED');
         break;
 
       default:
-        console.log('MISSING/INVALID TASK');
+        log('MISSING/INVALID TASK');
         break;
     }
 
     try {
       const response = await handler(_event) as LambdaProxyIntegrationResponse;
-      console.log(JSON.stringify(response, null, 2));
+      log(response);
     }
     catch(e) {
-      console.error(e);
+      log(e);
     }  
   })();
 }

--- a/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
+++ b/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
@@ -278,7 +278,7 @@ export const sendDisclosureRequest = async (consenterEmail:string, entity_id:str
     return errorResponse('Cannot determine disclosure request lambda function arn from environment!');
   }
 
-  const metadata = new BucketItemMetadata(new BucketItem({ email:consenterEmail } as Consenter));
+  const metadata = new BucketItemMetadata();
   const { EXHIBIT, DISCLOSURE } = ItemType;
 
   const s3ObjectKeyForExhibitForm = await metadata.getLatestS3ObjectKey({
@@ -334,10 +334,8 @@ export const sendDisclosureRequest = async (consenterEmail:string, entity_id:str
   }
 
   // Tag the pdfs so that they are skipped over by the event bridge stale pdf database purging rule:
-  const now = new Date().toISOString();
-  const bucket = new BucketItem({ email:consenterEmail } as Consenter);
-  const exhibitForm = new BucketExhibitForm(bucket, s3ObjectKeyForExhibitForm);
-  const disclosureForm = new BucketDisclosureForm({ bucket, metadata: s3ObjectKeyForDisclosureForm });
+  const exhibitForm = new BucketExhibitForm(s3ObjectKeyForExhibitForm);
+  const disclosureForm = new BucketDisclosureForm({ metadata: s3ObjectKeyForDisclosureForm });
   let tagged = false;
   tagged ||= await exhibitForm.tagWithDiclosureRequestSentDate();
   tagged &&= await disclosureForm.tagWithDiclosureRequestSentDate();

--- a/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
@@ -104,7 +104,7 @@ const grabFromBucketAndSend = async (parms:DisclosureEmailParms):Promise<boolean
     s3ObjectKeyForDisclosureForm
   }, null, 2)}`);
 
-  const { entityId, affiliateEmail } = BucketItemMetadata.fromBucketObjectKey(s3ObjectKeyForExhibitForm) ?? {};
+  const { entityId, affiliateEmail, savedDate } = BucketItemMetadata.fromBucketObjectKey(s3ObjectKeyForExhibitForm) ?? {};
   if( ! affiliateEmail) {
     console.error(`Cannot send disclosure ${emailType} email: Affiliate email unknown`);
     return false;
@@ -125,7 +125,7 @@ const grabFromBucketAndSend = async (parms:DisclosureEmailParms):Promise<boolean
   }();
 
   // Get the consenter correction forms
-  const correctionFormsBytes = await BucketCorrectionForm.getAll(consenterEmail);
+  const correctionFormsBytes = await BucketCorrectionForm.getAll(consenterEmail, savedDate);
   const correctionForms = correctionFormsBytes.map(bytes => {
     return new class implements IPdfForm {
       async getBytes(): Promise<Uint8Array> {
@@ -190,8 +190,8 @@ const send = async (parms:EmailParameters):Promise<boolean> => {
   for(let i=0; i<correctionForms.length; i++) {
     attachments.push({
       pdf: correctionForms[i],
-      name: `correction-form-${i}`,
-      description: `correction-form-${i}`
+      name: `correction-form-${i+1}`,
+      description: `correction-form-${i+1}`
     })
   };
 

--- a/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
@@ -63,7 +63,7 @@ export class BasicDisclosureRequest {
   private data:DisclosureFormData;
   private exhibitData:ExhibitFormData;
 
-  constructor(data:DisclosureFormData, exhibitData:ExhibitFormData ) {
+  constructor(data:DisclosureFormData, exhibitData:ExhibitFormData) {
     this.data = data;
     this.exhibitData = exhibitData;
   }
@@ -90,7 +90,7 @@ export class BasicDisclosureRequest {
 }
 
 /**
- * Retrieve the exhibit & disclosure forms from the s3 bucket and sent them as attachments in a disclosure
+ * Retrieve the exhibit & disclosure forms from the s3 bucket and send them as attachments in a disclosure
  * request email.
  * @param parms 
  * @returns 
@@ -109,12 +109,15 @@ const grabFromBucketAndSend = async (parms:DisclosureEmailParms):Promise<boolean
     console.error(`Cannot send disclosure ${emailType} email: Affiliate email unknown`);
     return false;
   }
+
+  // Get the exhibit form
   const singleExhibitForm = new class implements IPdfForm {
     async getBytes(): Promise<Uint8Array> {
       return new BucketExhibitForm(s3ObjectKeyForExhibitForm).get();
     }
   }();
 
+  // Get the disclosure form
   const disclosureForm = new class implements IPdfForm {
     async getBytes(): Promise<Uint8Array> {
       return new BucketDisclosureForm({ metadata: s3ObjectKeyForDisclosureForm }).get();

--- a/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
@@ -8,7 +8,7 @@ import { DisclosureForm, DisclosureFormData } from "../../_lib/pdf/DisclosureFor
 import { ExhibitForm } from "../../_lib/pdf/ExhibitForm";
 import { ExhibitFormSingle } from '../../_lib/pdf/ExhibitFormSingle';
 import { IPdfForm, PdfForm } from "../../_lib/pdf/PdfForm";
-import { BucketItem, DisclosureItemsParms } from "../consenting-person/BucketItem";
+import { DisclosureItemsParms } from "../consenting-person/BucketItem";
 import { BucketDisclosureForm } from "../consenting-person/BucketItemDisclosureForm";
 import { BucketExhibitForm } from "../consenting-person/BucketItemExhibitForm";
 import { BucketItemMetadata, ExhibitFormsBucketEnvironmentVariableName } from "../consenting-person/BucketItemMetadata";
@@ -111,19 +111,13 @@ const grabFromBucketAndSend = async (parms:DisclosureEmailParms):Promise<boolean
   }
   const singleExhibitForm = new class implements IPdfForm {
     async getBytes(): Promise<Uint8Array> {
-      return new BucketExhibitForm(
-        new BucketItem({ email:consenterEmail } as Consenter, bucketName),
-        s3ObjectKeyForExhibitForm
-      ).get();
+      return new BucketExhibitForm(s3ObjectKeyForExhibitForm).get();
     }
   }();
 
   const disclosureForm = new class implements IPdfForm {
     async getBytes(): Promise<Uint8Array> {
-      return new BucketDisclosureForm({
-        bucket: new BucketItem({ email:consenterEmail } as Consenter, bucketName),
-        metadata: s3ObjectKeyForDisclosureForm
-      }).get();
+      return new BucketDisclosureForm({ metadata: s3ObjectKeyForDisclosureForm }).get();
     }
   }();
 

--- a/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
@@ -15,6 +15,7 @@ import { BucketExhibitForm } from "../consenting-person/BucketItemExhibitForm";
 import { BucketItemMetadata } from "../consenting-person/BucketItemMetadata";
 import { test_data as test_exhibit_data } from '../consenting-person/ExhibitEmail';
 import { bugsbunny, daffyduck, yosemitesam } from "./MockObjects";
+import { log } from '../../Utils';
 
 
 export type DisclosureEmailParms = DisclosureItemsParms & {
@@ -98,11 +99,11 @@ export class BasicDisclosureRequest {
  */
 const grabFromBucketAndSend = async (parms:DisclosureEmailParms):Promise<boolean> => {
   const { consenterEmail, s3ObjectKeyForExhibitForm, s3ObjectKeyForDisclosureForm, emailType } = parms;
-  console.log(`Sending disclosure ${emailType}: ${JSON.stringify({ 
+  log({ 
     consenterEmail, 
     s3ObjectKeyForExhibitForm,
     s3ObjectKeyForDisclosureForm
-  }, null, 2)}`);
+  }, `Sending disclosure ${emailType}`);
 
   const { entityId, affiliateEmail, savedDate } = BucketItemMetadata.fromBucketObjectKey(s3ObjectKeyForExhibitForm) ?? {};
   if( ! affiliateEmail) {
@@ -216,7 +217,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_SEND_DISCLOSURE_FORM') {
   const email = process.env.PDF_RECIPIENT_EMAIL;
   
   if( ! email) {
-    console.log('Email environment variable is missing. Put PDF_RECIPIENT_EMAIL=[email] in .env in ${workspaceFolder}');
+    log('Email environment variable is missing. Put PDF_RECIPIENT_EMAIL=[email] in .env in ${workspaceFolder}');
     process.exit(1);
   }
 
@@ -231,7 +232,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_SEND_DISCLOSURE_FORM') {
 
   new BasicDisclosureRequest(test_disclosure_data, test_exhibit_data).send(email)
     .then(success => {
-      console.log(success ? 'Succeeded' : 'Failed');
+      log(success ? 'Succeeded' : 'Failed');
     })
     .catch(e => {
       console.error(e);

--- a/lib/lambda/functions/cognito/PreSignup.ts
+++ b/lib/lambda/functions/cognito/PreSignup.ts
@@ -2,6 +2,7 @@ import { lookupRole, lookupUserPoolClientId, lookupUserPoolId } from "../../_lib
 import { DAOFactory, DAOInvitation } from "../../_lib/dao/dao";
 import { ConsenterCrud } from "../../_lib/dao/dao-consenter";
 import { Consenter, Invitation, Role, Roles, Validator } from "../../_lib/dao/entity";
+import { debugLog } from "../../Utils";
 import { PreSignupEventType } from "./PreSignupEventType";
 
 export enum Messages {
@@ -11,12 +12,6 @@ export enum Messages {
   ROLE_MISSING = 'PreSignUp_AdminCreateUser did not send role information in event.request.clientMetadata',
   RETRACTED = 'Your invitation was retracted signup as '
 }
-
-const debugLog = (entry:String) => { 
-  if(process.env?.DEBUG === 'true') {
-    console.log(entry);
-  }
-};
 
 /**
  * Intercept all signup attempts early, before they reach the confirmation stage, and lookup the email in the
@@ -37,7 +32,7 @@ const debugLog = (entry:String) => {
  */
 export const handler = async (_event:any) => {
   try {
-    debugLog(JSON.stringify(_event, null, 2)); 
+    debugLog(_event); 
 
     const event = _event;
     const { userPoolId, region } = event;

--- a/lib/lambda/functions/consenting-person/BucketInventory.test.ts
+++ b/lib/lambda/functions/consenting-person/BucketInventory.test.ts
@@ -1,0 +1,132 @@
+import { BucketInventory } from "./BucketInventory";
+import { ListKeysOutput } from "./BucketItem";
+import { BucketItemMetadata, BucketItemMetadataParms, ItemType } from "./BucketItemMetadata";
+
+const { CORRECTION_FORM, EXHIBIT, DISCLOSURE } = ItemType;
+const day = 1000 * 60 * 60 * 24;
+const baseDate = new Date();
+const daysAgo = ((days:number) => { return new Date(baseDate.getTime() - (day * days)); });
+const daysAhead = ((days:number) => { return new Date(baseDate.getTime() + (day * days)); });
+const bugs = 'bunny@warnerbros.com';
+const daffy = 'duck@warnerbros.com';
+const foghorn = 'leghorn@warnerbros.com';
+const sam = 'yosemite@warnerbros.com';
+const aff1 = 'aff1@affiliates.org';
+const aff2 = 'aff2@affiliates.org';
+const aff3 = 'aff3@affiliates.org';
+
+const getMockKey = (unparsed:string) => {
+  const parts = unparsed.split('|');
+  const metadata = { 
+    consenterEmail:parts[0],
+    entityId:parts[1],
+    affiliateEmail:parts[2],
+    correction:parts[3]=='true',
+    itemType:parts[4],
+    savedDate:daysAhead(parseInt(parts[5]))
+  } as BucketItemMetadataParms;
+  return BucketItemMetadata.toBucketFileKey(metadata);
+}
+
+jest.mock('./BucketItem.ts', () => {
+  return {
+    BucketItem: jest.fn().mockImplementation(() => { 
+      return {        
+        listKeys: async (metadata:BucketItemMetadataParms): Promise<ListKeysOutput> => {
+          const { toBucketFolderKey } = BucketItemMetadata;
+          const { consenterEmail } = metadata;
+          const keys = [] as string[]
+          switch(consenterEmail) {
+            case bugs:
+              break;
+            case daffy:
+              keys.push(getMockKey(`${daffy}|entity1|${aff1}|false|${EXHIBIT}|0`));
+              break;
+            case foghorn:
+              keys.push(getMockKey(`${daffy}|entity1|${aff1}|false|${EXHIBIT}|0`));
+              keys.push(getMockKey(`${daffy}|entity1|${aff1}|true|${EXHIBIT}|1`));
+              keys.push(getMockKey(`${daffy}|entity1|${aff1}|true|${EXHIBIT}|2`));
+              break;
+            case sam:
+
+              // Mock 3 non-corrected affiliate-specific forms in the same consenter/entity1 directory
+              keys.push(getMockKey(`${sam}|entity1|${aff1}|false|${EXHIBIT}|0`));
+              keys.push(getMockKey(`${sam}|entity1|${aff2}|false|${EXHIBIT}|0`));
+              keys.push(getMockKey(`${sam}|entity1|${aff3}|false|${EXHIBIT}|0`));
+              // Mock 2 correction forms for each of the 3 mocked forms above.
+              keys.push(getMockKey(`${sam}|entity1|${aff1}|true|${EXHIBIT}|1`));
+              keys.push(getMockKey(`${sam}|entity1|${aff1}|true|${EXHIBIT}|2`));
+              keys.push(getMockKey(`${sam}|entity1|${aff2}|true|${EXHIBIT}|1`));
+              keys.push(getMockKey(`${sam}|entity1|${aff2}|true|${EXHIBIT}|2`));
+              keys.push(getMockKey(`${sam}|entity1|${aff3}|true|${EXHIBIT}|1`));
+              keys.push(getMockKey(`${sam}|entity1|${aff3}|true|${EXHIBIT}|2`));
+
+              // Mock 3 non-corrected affiliate-specific forms in  consenter/entity2 directory
+              keys.push(getMockKey(`${sam}|entity2|${aff1}|false|${EXHIBIT}|0`));
+              keys.push(getMockKey(`${sam}|entity2|${aff2}|false|${EXHIBIT}|0`));
+              keys.push(getMockKey(`${sam}|entity2|${aff3}|false|${EXHIBIT}|0`));
+              // Mock 2 correction forms for each of the 3 mocked forms above.
+              keys.push(getMockKey(`${sam}|entity2|${aff1}|true|${EXHIBIT}|1`));
+              keys.push(getMockKey(`${sam}|entity2|${aff1}|true|${EXHIBIT}|2`));
+              keys.push(getMockKey(`${sam}|entity2|${aff2}|true|${EXHIBIT}|1`));
+              keys.push(getMockKey(`${sam}|entity2|${aff2}|true|${EXHIBIT}|2`));
+              keys.push(getMockKey(`${sam}|entity2|${aff3}|true|${EXHIBIT}|1`));
+              keys.push(getMockKey(`${sam}|entity2|${aff3}|true|${EXHIBIT}|2`));
+          }
+
+          return { Prefix:toBucketFolderKey({ consenterEmail } as BucketItemMetadataParms), keys };          
+        } 
+      }
+    })
+  }
+})
+
+
+describe('BucketInventory.getAllLatestForms', () => {
+  it('Should pick out the youngest of related forms - none', async () => {
+    const inventory = await BucketInventory.getInstance(bugs);
+    const forms = inventory.getAllLatestForms();
+    expect(forms.length).toEqual(0);
+  });
+
+  it('Should pick out the youngest of related forms - single', async () => {
+    const inventory = await BucketInventory.getInstance(daffy);
+    const forms = inventory.getAllLatestForms();
+    expect(forms.length).toEqual(1);
+    expect(forms[0].savedDate?.getTime()).toEqual(baseDate.getTime());
+  });
+
+
+  it('Should pick out the youngest of related forms - basic', async () => {
+    const inventory = await BucketInventory.getInstance(foghorn);
+    const forms = inventory.getAllLatestForms();
+    expect(forms.length).toEqual(1);
+    expect(forms[0].savedDate?.getTime()).toEqual(daysAhead(2).getTime());
+  });
+
+  it('Should pick out the youngest of related forms - mixture', async () => {
+    const inventory = await BucketInventory.getInstance(sam);
+    const forms = inventory.getAllLatestForms();
+    expect(forms.length).toEqual(6);
+
+    // None of the results should have savedDates whose values are not 2 days out from the base date
+    let unexpectedItem = forms.find(metadata => {
+      return metadata.savedDate!.getTime() != daysAhead(2).getTime()
+    });
+    expect(unexpectedItem).toBeUndefined();
+
+    // None of the results should be other than exhibit forms
+    unexpectedItem = forms.find(metadata => {
+      return metadata.itemType != EXHIBIT
+    });
+    expect(unexpectedItem).toBeUndefined();
+
+    // Expect each of the 6 "youngest" forms to comprise the results.
+    expect(forms.find(m => m.entityId=='entity1' && m.affiliateEmail==aff1)).toBeDefined();
+    expect(forms.find(m => m.entityId=='entity1' && m.affiliateEmail==aff2)).toBeDefined();
+    expect(forms.find(m => m.entityId=='entity1' && m.affiliateEmail==aff3)).toBeDefined();
+    expect(forms.find(m => m.entityId=='entity2' && m.affiliateEmail==aff1)).toBeDefined();
+    expect(forms.find(m => m.entityId=='entity2' && m.affiliateEmail==aff2)).toBeDefined();
+    expect(forms.find(m => m.entityId=='entity2' && m.affiliateEmail==aff3)).toBeDefined();
+  })
+})

--- a/lib/lambda/functions/consenting-person/BucketInventory.ts
+++ b/lib/lambda/functions/consenting-person/BucketInventory.ts
@@ -1,5 +1,4 @@
 import { IContext } from "../../../../contexts/IContext";
-import { Consenter } from "../../_lib/dao/entity";
 import { BucketItem } from "./BucketItem";
 import { BucketItemMetadata, BucketItemMetadataParms, ExhibitFormsBucketEnvironmentVariableName, ItemType } from "./BucketItemMetadata";
 
@@ -18,9 +17,9 @@ export class BucketInventory {
   public static getInstance = async (consenterEmail:string, entityId?:string):Promise<BucketInventory> => {
     const inventory = new BucketInventory(consenterEmail, entityId);
     const { fromBucketObjectKey } = BucketItemMetadata
-    const bucketItem = new BucketItem({ email: consenterEmail } as Consenter);
+    const bucketItem = new BucketItem();
     const output = await bucketItem.listKeys({
-      entityId
+      consenterEmail, entityId
     } as BucketItemMetadataParms);
 
     const { Prefix, keys } = output;

--- a/lib/lambda/functions/consenting-person/BucketInventory.ts
+++ b/lib/lambda/functions/consenting-person/BucketInventory.ts
@@ -1,4 +1,5 @@
 import { IContext } from "../../../../contexts/IContext";
+import { log } from "../../Utils";
 import { BucketItem } from "./BucketItem";
 import { BucketItemMetadata, BucketItemMetadataParms, ExhibitFormsBucketEnvironmentVariableName, ItemType } from "./BucketItemMetadata";
 
@@ -190,9 +191,9 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_BUCKET_INVENTORY') {
     entityId = 'eea2d463-2eab-4304-b2cf-cf03cf57dfaa'
     const inventory = await BucketInventory.getInstance('cp3@warhen.work', entityId);
 
-    // console.log(JSON.stringify(inventory.getKeys(), null, 2));
-    // console.log(JSON.stringify(inventory.getAffiliateEmails(), null, 2));
-    console.log(JSON.stringify(inventory.getAffiliateForms('affiliate1@warhen.work', ItemType.EXHIBIT), null, 2))
-    // console.log(JSON.stringify(inventory.getLatestAffiliateItem('affiliate1@warhen.work', ItemType.EXHIBIT), null, 2));
+    // log(inventory.getKeys());
+    // log(inventory.getAffiliateEmails());
+    log(inventory.getAffiliateForms('affiliate1@warhen.work', ItemType.EXHIBIT));
+    // log(inventory.getLatestAffiliateItem('affiliate1@warhen.work', ItemType.EXHIBIT));
   })();
 }

--- a/lib/lambda/functions/consenting-person/BucketItemCorrectionForm.test.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemCorrectionForm.test.ts
@@ -1,0 +1,72 @@
+import { BucketCorrectionForm } from "./BucketItemCorrectionForm";
+import { BucketInventory } from "./BucketInventory";
+import { BucketItemMetadataParms, ItemType } from "./BucketItemMetadata";
+
+const day = 1000 * 60 * 60 * 24;
+const baseDate = new Date();
+const daysAgo = ((days:number) => { return new Date(baseDate.getTime() - (day * days)); });
+const daysAhead = ((days:number) => { return new Date(baseDate.getTime() + (day * days)); });
+
+jest.spyOn(BucketInventory, 'getInstance').mockImplementation(async (consenterEmail:string, entityId?:string) => {
+  const instance = new BucketInventory(consenterEmail, entityId);
+  const { CORRECTION_FORM, DISCLOSURE, EXHIBIT } = ItemType;
+  const contents = [] as BucketItemMetadataParms[];
+  switch(consenterEmail) {
+    case 'bugs@warnerbros.com': 
+      contents.push({ consenterEmail, entityId: 'entity_id1', affiliateEmail: 'email1', itemType:EXHIBIT, savedDate:daysAgo(1) });
+      contents.push({ consenterEmail, entityId: 'entity_id2', affiliateEmail: 'email2', itemType:DISCLOSURE, savedDate:daysAgo(2) });
+      contents.push({ consenterEmail, itemType:CORRECTION_FORM, savedDate:daysAgo(1) } as BucketItemMetadataParms);
+      break;
+    case 'daffy@warnerbros.com':
+      contents.push({ consenterEmail, entityId: 'entity_id1', affiliateEmail: 'email1', itemType:EXHIBIT, savedDate:daysAgo(1) });
+      contents.push({ consenterEmail, entityId: 'entity_id2', affiliateEmail: 'email2', itemType:DISCLOSURE, savedDate:daysAgo(2) });
+      contents.push({ consenterEmail, itemType:CORRECTION_FORM, savedDate:daysAgo(1) } as BucketItemMetadataParms);
+      contents.push({ consenterEmail, entityId: 'entity_id1', affiliateEmail: 'email2', itemType:EXHIBIT, savedDate:daysAhead(1)});
+      contents.push({ consenterEmail, entityId: 'entity_id2', affiliateEmail: 'email3', itemType:DISCLOSURE, savedDate:daysAhead(2)});
+      break;
+    case 'foghorn@warnerbros.com':
+      contents.push({ consenterEmail, itemType:CORRECTION_FORM, savedDate:daysAgo(1) } as BucketItemMetadataParms);
+      contents.push({ consenterEmail, entityId: 'entity_id1', affiliateEmail: 'email2', itemType:EXHIBIT, savedDate:daysAhead(1)});
+      contents.push({ consenterEmail, entityId: 'entity_id2', affiliateEmail: 'email3', itemType:DISCLOSURE, savedDate:daysAhead(2)});
+      break;
+    case 'yosemite@warnerbros.com':
+      break;    
+  }
+  (instance as any)['contents'] = contents;
+  return instance;
+});
+
+describe('BucketCorrectionForm.isRedundant', () => {
+
+  it('Should properly recognize a redundant correction form - 1', async () => {
+    const form = await BucketCorrectionForm.getInstanceForReading({
+      consenterEmail: 'bugs@warnerbros.com',
+      savedDate: baseDate
+    } as BucketItemMetadataParms);
+    expect(await form.isRedundant()).toEqual(false);
+  });
+
+  it('Should properly recognize a redundant correction form - 2', async () => {
+    const form = await BucketCorrectionForm.getInstanceForReading({
+      consenterEmail: 'daffy@warnerbros.com',
+      savedDate: baseDate
+    } as BucketItemMetadataParms);
+    expect(await form.isRedundant()).toEqual(false);
+  });
+
+  it('Should properly recognize a redundant correction form - 3', async () => {
+    const form = await BucketCorrectionForm.getInstanceForReading({
+      consenterEmail: 'foghorn@warnerbros.com',
+      savedDate: baseDate
+    } as BucketItemMetadataParms);
+    expect(await form.isRedundant()).toEqual(true);
+  });
+
+  it('Should properly recognize a redundant correction form - 4', async () => {
+    const form = await BucketCorrectionForm.getInstanceForReading({
+      consenterEmail: 'yosemiten@warnerbros.com',
+      savedDate: baseDate
+    } as BucketItemMetadataParms);
+    expect(await form.isRedundant()).toEqual(true);
+  });
+});

--- a/lib/lambda/functions/consenting-person/BucketItemCorrectionForm.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemCorrectionForm.ts
@@ -1,0 +1,260 @@
+import { S3 } from "@aws-sdk/client-s3";
+import { IContext } from "../../../../contexts/IContext";
+import { ConsenterCrud } from "../../_lib/dao/dao-consenter";
+import { Consenter } from "../../_lib/dao/entity";
+import { CorrectionForm } from "../../_lib/pdf/CorrectionForm";
+import { BucketInventory } from "./BucketInventory";
+import { BucketItem } from "./BucketItem";
+import { BucketItemMetadata, BucketItemMetadataParms, ExhibitFormsBucketEnvironmentVariableName, ItemType } from "./BucketItemMetadata";
+
+/**
+ * This class deals with "CRUD" operations against an s3 bucket with respect to consenter correction forms.
+ * Among actions performed are putting new pdf files into the bucket and retrieving them out as byte arrays.
+ */
+export class BucketCorrectionForm {
+  private oldConsenter:Consenter;
+  private newConsenter:Consenter;
+  // or...
+  private metadata:BucketItemMetadataParms;
+
+  private inventory:BucketInventory;
+
+  private constructor() { /* Do nothing - just blocking non-factory instance creation */ }
+  
+  /**
+   * Get an instance you plan to involve in rendering and saving a new correction form
+   * @param newConsenter 
+   * @param oldConsenter 
+   */
+  public static getInstanceForCreation = (newConsenter:Consenter, oldConsenter:Consenter):BucketCorrectionForm => {
+    const form = new BucketCorrectionForm();
+    form.newConsenter = newConsenter;
+    form.oldConsenter = oldConsenter;
+    return form;
+  }
+
+  /**
+   * Get an instance you that represents a correction form that already exists and you either plan to 
+   * pull out of the bucket or whose s3 object key you want to break into parts and use for analysis.
+   */
+  public static getInstanceForReading = async (metadata:string|BucketItemMetadataParms):Promise<BucketCorrectionForm> => {
+    const { fromBucketObjectKey } = BucketItemMetadata;
+    if(typeof metadata == 'string') {
+      // metadata is in the form of an s3 object key, so convert it to a metadata object.
+      metadata = fromBucketObjectKey(metadata);
+    }
+
+    if( ! metadata.itemType) {
+      metadata.itemType = ItemType.CORRECTION_FORM;
+    }
+    const form = new BucketCorrectionForm();
+
+    // If the provided metadata is specific to a file, return the instance.
+    if(metadata.savedDate) {
+      form.metadata = metadata;
+      return form;
+    }
+
+    // The provided metadata was not specific to a file, so query the bucket for the latest correction form.
+    const bimd = new BucketItemMetadata();
+    const singleMetadata = await bimd.getLatest(metadata) as BucketItemMetadataParms;
+    form.metadata = singleMetadata;
+    return form;
+  }
+
+  /**
+   * Render the consenter correction form pdf and drop in the top level bucket directory for the consenter
+   * @returns 
+   */
+  public add = async (pdf?:CorrectionForm):Promise<string> => {
+    const { toBucketFileKey, fromBucketObjectKey } = BucketItemMetadata;
+    const { CORRECTION_FORM } = ItemType;
+    const { oldConsenter, newConsenter } = this;
+    const bucket = new BucketItem();
+    const { bucketName:Bucket, region } = bucket;
+
+    try {
+      // Get the s3 object key for the consenter correction form pdf to be stored.
+      const Key = toBucketFileKey({
+        consenterEmail:newConsenter.email, itemType:CORRECTION_FORM, entityId:'all'
+      });
+      this.metadata = fromBucketObjectKey(Key);
+
+      // Create a new consenter correction form pdf file if one was not provided
+      if( ! pdf) {
+        pdf = new CorrectionForm(oldConsenter, newConsenter);
+      }
+
+      // Save the new consenter correction form pdf file to the s3 bucket
+      console.log(`Saving consenter correction form to the s3 bucket: ${Key}`);
+      const s3 = new S3({ region });
+      const Body = await pdf.getBytes();
+      console.log(`Adding ${Key}`);
+      await s3.putObject({ Bucket, Key, Body, ContentType: 'application/pdf' });
+
+      // Return the object key of the consenter correction form.
+      return Key;
+    }
+    catch(e) {
+      console.log(`ConsenterCorrectionFormBucket.add: ${JSON.stringify({ oldConsenter, newConsenter }, null, 2)}`);
+      throw(e);
+    }
+  }
+
+  /**
+   * A consenter correction form is redundant if there is no other sendable form type whose timestamp indicates 
+   * it was rendered BEFORE the correction form itself was created. By "sendable" is meant either a form that
+   * has not been corrected, or its most recent correction. The idea here is that any such form rendered AFTER a
+   * correction form is submitted would reflect those corrections anyway.
+   * @param inventory 
+   */
+  public isRedundant = async (inventory:BucketInventory=this.inventory):Promise<boolean> => {
+    const { metadata: { consenterEmail, savedDate } } = this;
+    if( ! inventory) {
+      inventory = await BucketInventory.getInstance(consenterEmail);
+      this.inventory = inventory;
+    }
+    const contents = inventory.getAllLatestForms();
+    const dependents = contents.filter(metadata => {
+      const { itemType, savedDate:date } = metadata;
+      return itemType != ItemType.CORRECTION_FORM && date!.getTime() < savedDate!.getTime();
+    });
+    return dependents.length == 0;
+  }
+
+  /**
+   * Get the most recent consenter correction form
+   * @returns 
+   */
+  public get = async (): Promise<Uint8Array> => {
+    const { CORRECTION_FORM } = ItemType;
+    const { metadata: { consenterEmail, savedDate, itemType=CORRECTION_FORM }} = this;
+    const { toBucketFileKey } = BucketItemMetadata;
+    const bucket = new BucketItem();
+    try {
+      const { bucketName:Bucket, region } = bucket;
+      let metadata:BucketItemMetadataParms|undefined;
+
+      // Lookup the most recently saved correction form if the metadata is not specific to a single file
+      if( ! savedDate) {
+        const bimd = new BucketItemMetadata();
+        metadata = await bimd.getLatest({ consenterEmail, itemType:CORRECTION_FORM } as BucketItemMetadataParms);
+      }
+      else {
+        metadata = { consenterEmail, savedDate, itemType } as BucketItemMetadataParms;
+      }
+
+      // Bail out if metadata could not be determined
+      if( ! metadata) {
+        return new Uint8Array(); // Return an empty array
+      }
+
+      // Get the s3 object key for the specific pdf file
+      const Key = toBucketFileKey(metadata);
+
+      // Get the bytes for the specific pdf file out of the bucket.
+      const s3 = new S3({ region });
+      const output = await s3.getObject({ Bucket, Key });
+      const { Body } = output;
+      if(Body) {
+        return Body.transformToByteArray();
+      }
+      return new Uint8Array(); // Return an empty array
+    }
+    catch(e) {
+      console.log(`ConsenterCorrectionFormBucket.get: ${consenterEmail}`);
+      throw(e);
+    }
+  }
+
+  public Delete = async () => {
+    const { metadata } =  this;
+    const bucket = new BucketItem();
+    return bucket.deleteSingleItem(metadata);
+  }
+
+  /**
+   * Search the bucket for any existing sendable exhibit or disclosure forms for the consenter. 
+   * By "sendable" is meant either a form that has not been corrected, or its most recent correction. 
+   * If any are found AND they predate any consenter correction forms that can also be found for that 
+   * consenter, return the correction forms - they will be included in related disclosure request and 
+   * reminder emails.
+   * @param consenterEmail 
+   * @param pruneRedundantForms 
+   * @returns 
+   */
+  public static getAll = async (consenterEmail:string, pruneRedundantForms:boolean=true): Promise<Uint8Array[]> => {
+    const { getInstanceForReading } = BucketCorrectionForm;
+    const pdfs = [] as Uint8Array[];
+    try {
+      const inventory = await BucketInventory.getInstance(consenterEmail);
+      const correctionForms = inventory.getAllFormsOfType(ItemType.CORRECTION_FORM);
+      if(correctionForms.length == 0) {
+        return [];
+      }
+
+      for(let i=0; i<correctionForms.length; i++) {
+        const metadata = correctionForms[i];
+        const form = await getInstanceForReading(metadata);
+        if(await form.isRedundant(inventory)) {
+          if(pruneRedundantForms) {
+            console.log(`Deleting redundant consenter correction form: ${metadata}`);
+            await form.Delete();
+          }
+          continue;
+        }
+        const pdf = await form.get();
+        pdfs.push(pdf);
+      }
+
+      return pdfs;
+    }
+    catch(e) {
+      console.log(`ConsenterCorrectionFormBucket.get: ${consenterEmail}`);
+      throw(e);
+    }    
+  }
+}
+
+
+
+
+/**
+ * RUN MANUALLY: Modify consenter and entityId as necessary.
+ */
+const { argv:args } = process;
+if(args.length > 4 && args[2] == 'RUN_MANUALLY_CONSENTER_CORRECTION_FORM') {
+
+  const task = args[3] as 'add'|'get'|'get-all'
+
+  const consenter = { email:'cp3@warhen.work' } as Consenter;
+
+  (async() => {
+    const context:IContext = await require('../../../../contexts/context.json');
+    const { STACK_ID, REGION, TAGS: { Landscape }} = context;
+    const prefix = `${STACK_ID}-${Landscape}`;
+    process.env.REGION = REGION;
+
+    let bucket:BucketCorrectionForm;
+    let entityId:string;
+    process.env[ExhibitFormsBucketEnvironmentVariableName] = `${prefix}-exhibit-forms`;
+
+    const oldConsenter = await ConsenterCrud({ email:'cp2@warhen.work' } as Consenter).read() as Consenter;
+
+    const newConsenter = Object.assign({}, oldConsenter);
+    newConsenter.email = 'cp1@warhen.work';
+    newConsenter.lastname = `${oldConsenter.lastname} (corrected)`;
+
+    switch(task) {
+      case "add":
+        const form = BucketCorrectionForm.getInstanceForCreation(newConsenter, oldConsenter);
+        break;
+      case "get":
+        console.log('NOT IMPLEMENTED');
+        break;
+      case "get-all":
+        console.log('NOT IMPLEMENTED');
+        break;
+    }
+  })();
+}

--- a/lib/lambda/functions/consenting-person/BucketItemCorrectionForm.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemCorrectionForm.ts
@@ -6,6 +6,7 @@ import { CorrectionForm } from "../../_lib/pdf/CorrectionForm";
 import { BucketInventory } from "./BucketInventory";
 import { BucketItem } from "./BucketItem";
 import { BucketItemMetadata, BucketItemMetadataParms, ExhibitFormsBucketEnvironmentVariableName, ItemType } from "./BucketItemMetadata";
+import { log } from "../../Utils";
 
 /**
  * This class deals with "CRUD" operations against an s3 bucket with respect to consenter correction forms.
@@ -86,17 +87,17 @@ export class BucketCorrectionForm {
       }
 
       // Save the new consenter correction form pdf file to the s3 bucket
-      console.log(`Saving consenter correction form to the s3 bucket: ${Key}`);
+      log(`Saving consenter correction form to the s3 bucket: ${Key}`);
       const s3 = new S3({ region });
       const Body = await pdf.getBytes();
-      console.log(`Adding ${Key}`);
+      log(`Adding ${Key}`);
       await s3.putObject({ Bucket, Key, Body, ContentType: 'application/pdf' });
 
       // Return the object key of the consenter correction form.
       return Key;
     }
     catch(e) {
-      console.log(`ConsenterCorrectionFormBucket.add: ${JSON.stringify({ oldConsenter, newConsenter }, null, 2)}`);
+      log({ oldConsenter, newConsenter }, `ConsenterCorrectionFormBucket.add`);
       throw(e);
     }
   }
@@ -162,7 +163,7 @@ export class BucketCorrectionForm {
       return new Uint8Array(); // Return an empty array
     }
     catch(e) {
-      console.log(`ConsenterCorrectionFormBucket.get: ${consenterEmail}`);
+      log(`ConsenterCorrectionFormBucket.get: ${consenterEmail}`);
       throw(e);
     }
   }
@@ -198,7 +199,7 @@ export class BucketCorrectionForm {
         const form = await getInstanceForReading(metadata);
         if(await form.isRedundant(inventory)) {
           if(pruneRedundantForms) {
-            console.log(`Deleting redundant consenter correction form: ${metadata}`);
+            log(`Deleting redundant consenter correction form: ${metadata}`);
             await form.Delete();
           }
           continue;
@@ -213,7 +214,7 @@ export class BucketCorrectionForm {
       return pdfs;
     }
     catch(e) {
-      console.log(`ConsenterCorrectionFormBucket.get: ${consenterEmail}`);
+      log(`ConsenterCorrectionFormBucket.get: ${consenterEmail}`);
       throw(e);
     }    
   }
@@ -253,10 +254,10 @@ if(args.length > 4 && args[2] == 'RUN_MANUALLY_CONSENTER_CORRECTION_FORM') {
         const form = BucketCorrectionForm.getInstanceForCreation(newConsenter, oldConsenter);
         break;
       case "get":
-        console.log('NOT IMPLEMENTED');
+        log('NOT IMPLEMENTED');
         break;
       case "get-all":
-        console.log('NOT IMPLEMENTED');
+        log('NOT IMPLEMENTED');
         break;
     }
   })();

--- a/lib/lambda/functions/consenting-person/BucketItemCorrectionForm.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemCorrectionForm.ts
@@ -183,7 +183,7 @@ export class BucketCorrectionForm {
    * @param pruneRedundantForms 
    * @returns 
    */
-  public static getAll = async (consenterEmail:string, pruneRedundantForms:boolean=true): Promise<Uint8Array[]> => {
+  public static getAll = async (consenterEmail:string, createdAfter:Date=new Date(), pruneRedundantForms:boolean=true): Promise<Uint8Array[]> => {
     const { getInstanceForReading } = BucketCorrectionForm;
     const pdfs = [] as Uint8Array[];
     try {
@@ -203,8 +203,11 @@ export class BucketCorrectionForm {
           }
           continue;
         }
-        const pdf = await form.get();
-        pdfs.push(pdf);
+        const { savedDate } = metadata;
+        if( savedDate!.getTime() > createdAfter.getTime()) {
+          const pdf = await form.get();
+          pdfs.push(pdf);
+        }
       }
 
       return pdfs;

--- a/lib/lambda/functions/consenting-person/BucketItemDisclosureForm.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemDisclosureForm.ts
@@ -4,6 +4,7 @@ import { Consenter, Entity, Roles, User, YN } from "../../_lib/dao/entity";
 import { DisclosureForm, DisclosureFormData } from "../../_lib/pdf/DisclosureForm";
 import { BucketItem, Tags } from "./BucketItem";
 import { BucketItemMetadata, BucketItemMetadataParms, ItemType } from "./BucketItemMetadata";
+import { log } from "../../Utils";
 
 export type BucketDisclosureFormParms = {
   metadata:BucketItemMetadataParms|string,
@@ -106,14 +107,14 @@ export class BucketDisclosureForm {
       // Save the new single exhibit form pdf file to the s3 bucket
       const s3 = new S3({ region });
       const Body = await pdf.getBytes();
-      console.log(`Adding ${Key}`);
+      log(`Adding ${Key}`);
       await s3.putObject({ Bucket, Key, Body, ContentType: 'application/pdf' });
 
       // Return the object key of the exhibit form.
       return Key;
     }
     catch(e) {
-      console.log(`DisclosureFormBucket.add: ${JSON.stringify(metadata, null, 2)}`);
+      log(metadata, `DisclosureFormBucket.add`);
       throw(e);
     }
   }
@@ -135,7 +136,7 @@ export class BucketDisclosureForm {
       return bucket.getObjectBytes(metadata);
     }
     catch(e) {
-      console.log(`DisclosureFormBucket.get: ${JSON.stringify({ bucket, metadata }, null, 2)}`);
+      log({ bucket, metadata }, `DisclosureFormBucket.get`);
       throw(e);
     }
   }

--- a/lib/lambda/functions/consenting-person/BucketItemExhibitForm.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemExhibitForm.ts
@@ -34,7 +34,7 @@ export class BucketExhibitForm {
     const { exhibit_forms=[] } = consenter;
     let { metadata, metadata: { 
       consenterEmail, entityId, affiliateEmail, correction=_correction, savedDate=new Date() }, 
-      bucket, bucket: { bucketName:Bucket, region }
+      bucket: { bucketName:Bucket, region }
     } = this;
 
     try {

--- a/lib/lambda/functions/consenting-person/BucketItemExhibitForm.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemExhibitForm.ts
@@ -4,6 +4,7 @@ import { ExhibitForm } from "../../_lib/pdf/ExhibitForm";
 import { ExhibitFormSingle } from "../../_lib/pdf/ExhibitFormSingle";
 import { BucketItem, Tags } from "./BucketItem";
 import { BucketItemMetadata, BucketItemMetadataParms, ItemType } from "./BucketItemMetadata";
+import { log } from "../../Utils";
 
 /**
  * This class deals with "CRUD" operations against a single exhibit form in the s3 bucket.
@@ -66,14 +67,14 @@ export class BucketExhibitForm {
       // Save the new single exhibit form pdf file to the s3 bucket
       const s3 = new S3({ region });
       const Body = await pdf.getBytes();
-      console.log(`Adding ${Key}`);
+      log(`Adding ${Key}`);
       await s3.putObject({ Bucket, Key, Body, ContentType: 'application/pdf' });
 
       // Return the object key of the exhibit form.
       return Key;
     }
     catch(e) {
-      console.log(`ExhibitBucket.add: ${JSON.stringify({ bucket, metadata }, null, 2)}`);
+      log(metadata, `ExhibitBucket.add`);
       throw(e);
     }
   }
@@ -88,7 +89,7 @@ export class BucketExhibitForm {
       return bucket.getObjectBytes(metadata);
     }
     catch(e) {
-      console.log(`ExhibitBucket.get: ${JSON.stringify({ bucket, metadata }, null, 2)}`);
+      log({ bucket, metadata }, `ExhibitBucket.get`);
       throw(e);
     }
   }
@@ -225,7 +226,7 @@ if(args.length > 4 && args[2] == 'RUN_MANUALLY_CONSENTER_EXHIBIT_FORM') {
         await exhibitForm.delete();
         break;
       case "get":
-        console.log('Not implemented');
+        log('Not implemented');
         break;
     }
   })();

--- a/lib/lambda/functions/consenting-person/BucketItemExhibitForm.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemExhibitForm.ts
@@ -1,5 +1,4 @@
 import { S3 } from "@aws-sdk/client-s3";
-import { IContext } from "../../../../contexts/IContext";
 import { Affiliate, AffiliateTypes, Consenter, YN } from "../../_lib/dao/entity";
 import { ExhibitForm } from "../../_lib/pdf/ExhibitForm";
 import { ExhibitFormSingle } from "../../_lib/pdf/ExhibitFormSingle";
@@ -13,10 +12,10 @@ export class BucketExhibitForm {
   private metadata:BucketItemMetadataParms;
   private bucket:BucketItem;
 
-  constructor(bucket:BucketItem, metadata:BucketItemMetadataParms|string) {
+  constructor(metadata:BucketItemMetadataParms|string) {
     const { fromBucketObjectKey } = BucketItemMetadata;
 
-    this.bucket = bucket;
+    this.bucket = new BucketItem();
     if(typeof metadata == 'string') {
       // parms is in the form of an s3 object key, so convert it to a metadata object.
       this.metadata = fromBucketObjectKey(metadata);
@@ -29,11 +28,12 @@ export class BucketExhibitForm {
    * Add the disclosure form to the bucket.
    * @returns 
    */
-  public add = async (_correction:boolean=false):Promise<string> => {
+  public add = async (consenter:Consenter, _correction:boolean=false):Promise<string> => {
     const { EXHIBIT } = ItemType;
+    const { exhibit_forms=[] } = consenter;
     let { metadata, metadata: { 
-      entityId, affiliateEmail, correction=_correction, savedDate=new Date() }, 
-      bucket, bucket: { consenter, consenter: { email:consenterEmail, exhibit_forms=[] }, bucketName:Bucket, region }
+      consenterEmail, entityId, affiliateEmail, correction=_correction, savedDate=new Date() }, 
+      bucket, bucket: { bucketName:Bucket, region }
     } = this;
 
     try {
@@ -105,8 +105,8 @@ export class BucketExhibitForm {
   /**
    * Add a corrected single exhibit form to the bucket
    */
-  public correct = async ():Promise<string> => {
-    return this.add(true);
+  public correct = async (consenter:Consenter):Promise<string> => {
+    return this.add(consenter, true);
   }
 
   /**
@@ -200,32 +200,28 @@ if(args.length > 4 && args[2] == 'RUN_MANUALLY_CONSENTER_EXHIBIT_FORMS') {
   let affiliateEmail:string;
 
   (async () => {
-    const context:IContext = await require('../../../../contexts/context.json');
-    const { STACK_ID, TAGS: { Landscape }} = context;
-    const bucketItem = new BucketItem(consenter, `${STACK_ID}-${Landscape}-exhibit-forms`);
-    
     switch(task) {
       case "add":
         entityId = consenter.exhibit_forms![0].entity_id;
         affiliateEmail = consenter.exhibit_forms![0].affiliates![0].email;
-        exhibitForm = new BucketExhibitForm(bucketItem, {
-           entityId, affiliateEmail, savedDate:dummyDate 
+        exhibitForm = new BucketExhibitForm({
+           consenterEmail:consenter.email, entityId, affiliateEmail, savedDate:dummyDate 
         } as BucketItemMetadataParms);
-        await exhibitForm.add();
+        await exhibitForm.add(consenter);
         break;
       case "correct":
         entityId = 'eea2d463-2eab-4304-b2cf-cf03cf57dfaa';
         affiliateEmail = 'affiliate1@warhen.work';
-        exhibitForm = new BucketExhibitForm(bucketItem, {
-          entityId, affiliateEmail, savedDate:dummyDate 
+        exhibitForm = new BucketExhibitForm({
+          consenterEmail:consenter.email, entityId, affiliateEmail, savedDate:dummyDate 
         } as BucketItemMetadataParms);
-        await exhibitForm.correct();
+        await exhibitForm.correct(consenter);
         break;
       case "delete":
         entityId = consenter.exhibit_forms![0].entity_id;
         affiliateEmail = consenter.exhibit_forms![0].affiliates![2].email;
-        const metadata = { itemType:EXHIBIT, entityId, affiliateEmail, correction:true, savedDate:dummyDate}
-        exhibitForm = new BucketExhibitForm(bucketItem, metadata);
+        const metadata = { itemType:EXHIBIT, consenterEmail:consenter.email, entityId, affiliateEmail, correction:true, savedDate:dummyDate}
+        exhibitForm = new BucketExhibitForm(metadata);
         await exhibitForm.delete();
         break;
       case "get":

--- a/lib/lambda/functions/consenting-person/BucketItemExhibitForm.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemExhibitForm.ts
@@ -17,7 +17,7 @@ export class BucketExhibitForm {
 
     this.bucket = new BucketItem();
     if(typeof metadata == 'string') {
-      // parms is in the form of an s3 object key, so convert it to a metadata object.
+      // metadata is in the form of an s3 object key, so convert it to a metadata object.
       this.metadata = fromBucketObjectKey(metadata);
       return;
     }
@@ -136,7 +136,7 @@ export class BucketExhibitForm {
  * RUN MANUALLY: Modify the region, task, and deleteDepth as needed.
  */
 const { argv:args } = process;
-if(args.length > 4 && args[2] == 'RUN_MANUALLY_CONSENTER_EXHIBIT_FORMS') {
+if(args.length > 4 && args[2] == 'RUN_MANUALLY_CONSENTER_EXHIBIT_FORM') {
 
   // Process args:
   const region = args[3];

--- a/lib/lambda/functions/consenting-person/BucketItemExhibitForms.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemExhibitForms.ts
@@ -4,6 +4,7 @@ import { AffiliateTypes, Consenter, ExhibitForm as ExhibitFormData, YN } from ".
 import { BucketItem } from "./BucketItem";
 import { BucketExhibitForm } from "./BucketItemExhibitForm";
 import { BucketItemMetadata, BucketItemMetadataParms, ExhibitFormsBucketEnvironmentVariableName, ItemType } from "./BucketItemMetadata";
+import { log } from "../../Utils";
 
 
 /**
@@ -19,7 +20,7 @@ export class ExhibitBucket {
   }
 
   private putAll = async (entityId:string, task:'add'|'correct', savedDate?:Date):Promise<string[]> => {
-    console.log(`Adding each ${task=='add' ? 'new' : 'corrected'} single exhibit form to bucket: ${JSON.stringify({entityId, savedDate }, null, 2)}`);
+    log({entityId, savedDate }, `Adding each ${task=='add' ? 'new' : 'corrected'} single exhibit form to bucket`);
     const { consenter, bucket, consenter: { email:consenterEmail, exhibit_forms }} = this;
     const exhibitForm:ExhibitFormData|undefined = exhibit_forms?.find(ef => {
       return ef.entity_id = entityId;
@@ -84,7 +85,7 @@ export class ExhibitBucket {
       const output = await listKeys(metadata);
       const { keys } = output;
       if( keys.length === 0) {
-        console.log(`No single exhibit forms found in ${Prefix}`);
+        log(`No single exhibit forms found in ${Prefix}`);
         return;
       }
 
@@ -114,7 +115,7 @@ export class ExhibitBucket {
       return deleteResult;
     }
     catch(e) {
-      console.log(`ExhibitBucket.delete: ${JSON.stringify({ bucket:this.bucket, parms: metadata }, null, 2)}`);
+      log({ bucket:this.bucket, parms: metadata }, `ExhibitBucket.delete`);
       throw(e);
     }
   }
@@ -141,14 +142,13 @@ export class ExhibitBucket {
       const output = await listKeys(metadata);
       const { keys } = output;
       if( keys.length === 0) {
-        console.log(`No single exhibit forms found in ${Prefix}`);
+        log(`No single exhibit forms found in ${Prefix}`);
         return emptyArray;
       }
 
       // Print out objects that would be fetched if dryrun and return
       if(dryrun) {
-        console.log(`Get results for s3 prefix: ${Prefix}
-        ${JSON.stringify(keys, null, 2)}`);
+        log(keys, `Get results for s3 prefix: ${Prefix}`);
         return emptyArray;
       }
 
@@ -167,7 +167,7 @@ export class ExhibitBucket {
       return pdfs
     }
     catch(e) {
-      console.log(`ExhibitBucket.query: ${JSON.stringify({ bucket:this.bucket, parms: metadata }, null, 2)}`);
+      log({ bucket:this.bucket, parms: metadata }, `ExhibitBucket.query`);
       throw(e);
     }
   }
@@ -252,7 +252,7 @@ if(args.length > 4 && args[2] == 'RUN_MANUALLY_CONSENTER_EXHIBIT_FORMS') {
         entityId = consenter.exhibit_forms![0].entity_id;
         bucket.addAll(entityId, dummyDate)
           .then(() => {
-            console.log('done');
+            log('done');
           })
           .catch(e => {
             console.error(e);
@@ -280,7 +280,7 @@ if(args.length > 4 && args[2] == 'RUN_MANUALLY_CONSENTER_EXHIBIT_FORMS') {
         }
         bucket.deleteAll(metadata)
           .then(() => {
-            console.log('done');
+            log('done');
           })
           .catch(e => {
             console.error(e);

--- a/lib/lambda/functions/consenting-person/BucketItemMetadata.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemMetadata.ts
@@ -3,7 +3,7 @@ import { BucketItem } from "./BucketItem";
 export const ExhibitFormsBucketEnvironmentVariableName = 'EXHIBIT_FORMS_BUCKET_NAME';
 
 export enum ItemType {
-  EXHIBIT = 'exhibit', DISCLOSURE = 'disclosure'
+  EXHIBIT = 'exhibit', DISCLOSURE = 'disclosure', CORRECTION_FORM = 'correction'
 }
 export type BucketItemMetadataParms = {
   consenterEmail: string,
@@ -38,6 +38,7 @@ export class BucketItemMetadata {
    */
   public getLatest = async (metadata:BucketItemMetadataParms|string): Promise<BucketItemMetadataParms|undefined> => {
     const { bucket } = this;
+    const { CORRECTION_FORM } = ItemType;
     if(typeof metadata == 'string') {
       // metadata is in the form of an s3 object key, so convert it to a metadata object.
       metadata = BucketItemMetadata.fromBucketObjectKey(metadata);
@@ -50,12 +51,12 @@ export class BucketItemMetadata {
       return undefined;
     }
     
-    if( ! entityId) {
+    if( ! entityId && itemType != CORRECTION_FORM) {
       console.log(`Invalid parameters for ${itemType} form lookup in s3, entity_id missing: ${JSON.stringify(metadata, null, 2)}`);
       return undefined;
     }
 
-    if( ! affiliateEmail) {
+    if( ! affiliateEmail && itemType != CORRECTION_FORM) {
       console.log(`Invalid parameters for ${itemType} form lookup in s3, affiliateEmail missing: ${JSON.stringify(metadata, null, 2)}`);
       return undefined;
     }
@@ -126,8 +127,27 @@ export class BucketItemMetadata {
       return undefined;
     }
     return s3ObjectKey;
-  }  
+  }
 
+  /**
+   * @param f1 
+   * @param f2 
+   * @returns true if 2 forms exist under a consenter/entityId/affiliate subdirectory, and one is a 
+   * correction and the other is either another correction or the original, or both are the same form.
+   */
+  public static areRelated = (f1:BucketItemMetadataParms, f2:BucketItemMetadataParms):boolean => {
+    if(f1.consenterEmail != f2.consenterEmail) return false;
+    if(f1.itemType == ItemType.CORRECTION_FORM || f2.itemType == ItemType.CORRECTION_FORM) return false;
+    if(f1.entityId != f2.entityId) return false;
+    if(f1.affiliateEmail != f2.affiliateEmail) return false;
+    if(f1.itemType != f2.itemType) return false;
+    return true;
+  }
+
+  public static areEqual = (f1:BucketItemMetadataParms, f2:BucketItemMetadataParms):boolean => {
+    if( ! BucketItemMetadata.areRelated(f1, f2)) return false;
+    return f1.savedDate == f2.savedDate;
+  }
   
   /**
    * Convert a consenters single set of exhibit form metadata parms into an s3 object key.
@@ -136,6 +156,7 @@ export class BucketItemMetadata {
    * @returns 
    */
   private static toBucketPath = (metadata:BucketItemMetadataParms):string => {
+
     const { itemType, consenterEmail, affiliateEmail, entityId='all', correction, savedDate=(new Date(Date.now())) } = metadata;
 
     if( ! consenterEmail) {
@@ -164,6 +185,11 @@ export class BucketItemMetadata {
 
     const { encode, getEncodedEmail, getSafeIsoDate} = helpers;
 
+    // If a consenter correction form is indicated, return a consenterEmail/pdfFile s3 path
+    if( ( ! entityId || entityId == 'all' ) && itemType == ItemType.CORRECTION_FORM) {
+      return `${getEncodedEmail(consenterEmail)}/${itemType}-${getSafeIsoDate()}.pdf`;
+    }
+
     // If the entity_id value is "all", then return an object key that stops at the consenter.
     if( entityId == 'all') {
       return `${getEncodedEmail(consenterEmail)}`;
@@ -190,11 +216,13 @@ export class BucketItemMetadata {
    */
   public static toBucketFileKey = (metadata:BucketItemMetadataParms):string => {
     const { itemType, entityId, affiliateEmail } = metadata;
-    if( ! entityId ) {
-      throw new Error(`Provided metadata cannot specify a file without entityId: ${JSON.stringify(metadata, null, 2)}`);
-    }
-    if( ! affiliateEmail ) {
-      throw new Error(`Provided metadata cannot specify a file without affiliateEmail: ${JSON.stringify(metadata, null, 2)}`);
+    if(itemType != ItemType.CORRECTION_FORM) {
+      if( ! entityId ) {
+        throw new Error(`Provided metadata cannot specify a file without entityId: ${JSON.stringify(metadata, null, 2)}`);
+      }
+      if( ! affiliateEmail ) {
+        throw new Error(`Provided metadata cannot specify a file without affiliateEmail: ${JSON.stringify(metadata, null, 2)}`);
+      }
     }
     if( ! itemType ) {
       throw new Error(`Provided metadata cannot specify a file without itemType: ${JSON.stringify(metadata, null, 2)}`);
@@ -223,6 +251,29 @@ export class BucketItemMetadata {
    * @returns 
    */
   public static fromBucketObjectKey = (key:string):BucketItemMetadataParms => {
+    const isConsenterCorrectionForm = (name:string):boolean => {
+      return name.toLowerCase().trim().endsWith('.pdf') && name.includes(ItemType.CORRECTION_FORM); 
+    };
+
+    /**
+     * Given the name of a file, break it into its parts and add those parts to the provided metadata object
+     * @param name 
+     * @returns 
+     */
+    const complementMetadataWithFileName = (metadata:BucketItemMetadataParms, filename:string) => {
+      filename = filename.replace(/\.pdf$/, '').replace(/\!/g, ':');
+      const itemType = filename.substring(0, filename.indexOf('-')) as ItemType;
+      const isoStr = filename.substring(filename.indexOf('-')+1, filename.length);
+      const savedDate = new Date(isoStr);
+      metadata.itemType = itemType;
+      metadata.savedDate = savedDate;
+      const bucket = new BucketItem();
+      metadata.getTag = async (tagname:string):Promise<string|undefined> => {      
+        return bucket.getTag(metadata, tagname);
+      }
+      return metadata;
+    }
+
     // Trim off any trailing "/" characters
     if(key.trim().endsWith('/')) {
       return BucketItemMetadata.fromBucketObjectKey(key.substring(0, key.lastIndexOf('/')));
@@ -234,47 +285,44 @@ export class BucketItemMetadata {
     // Split the object key as if a path into its separate subfolders and filename. 
     const parts = key.split('/');
 
-    // 1) Restore the consenter email portion from the object key:
+    // Restore the consenter email portion from the object key:
     let emailParts = parts[0].split('(at)');
     const consenterEmail = `${decode(emailParts[0])}@${decode(emailParts[1])}`;
     if(parts.length < 2) {
       return { consenterEmail } as BucketItemMetadataParms;
     }
 
-    // 2) Restore the entity_id portion from the object key:
+    // Check to see if this is a consenter correction form
+    if(parts.length == 2 && isConsenterCorrectionForm(parts[1])) {
+      const metadata = { consenterEmail } as BucketItemMetadataParms;
+      return complementMetadataWithFileName(metadata, parts[1]);
+    }
+
+    // Restore the entity_id portion from the object key:
     const entityId = decode(parts[1]);
-    if(parts.length < 3) {
+    if(parts.length < 3 ) {
       return { consenterEmail, entityId } as BucketItemMetadataParms;
     };
 
-    // 3) Restore the affiliate email portion from the object key:
+    // Restore the affiliate email portion from the object key:
     emailParts = parts[2].split('(at)');
     const affiliateEmail = `${decode(emailParts[0])}@${decode(emailParts[1])}`;
     if(parts.length < 4) {
       return { consenterEmail, entityId, affiliateEmail } as BucketItemMetadataParms;
     }
 
-    // 4) If the object key only specifies a directory, return the corresponding metadata now
+    // If the object key only specifies a directory, return the corresponding metadata now
     if(parts[parts.length-1] == 'CORRECTED' || parts.length < 4) {
       return { consenterEmail, affiliateEmail, entityId } as BucketItemMetadataParms
     }
 
-    // 5) Restore the 'CORRECTED' portion from the object key if indicated:
+    // Restore the 'CORRECTED' portion from the object key if indicated:
     const correction = parts[3] == 'CORRECTED';
-    const name = (correction ? parts[4] : parts[3]).replace(/\.pdf$/, '').replace(/\!/g, ':');
-    const itemType = name.substring(0, name.indexOf('-')) as ItemType;
-    const isoStr = name.substring(name.indexOf('-')+1, name.length);
+    const name = correction ? parts[4] : parts[3];
 
-    // 6) Restore the file name itself from the object key:
-    const savedDate = new Date(isoStr);
-
-    // 7) Return the restored metadata object:
-    const metadata = { itemType, consenterEmail, affiliateEmail, entityId, correction, savedDate } as BucketItemMetadataParms;
-    const bucket = new BucketItem();
-    metadata.getTag = async (tagname:string):Promise<string|undefined> => {      
-      return bucket.getTag(metadata, tagname);
-    }
-    return metadata;
+    // Restore the file name itself from the object key and return the restored metadata objec:
+    const metadata = { consenterEmail, affiliateEmail, entityId, correction } as BucketItemMetadataParms;
+    return complementMetadataWithFileName(metadata, name);
   }
 
 }

--- a/lib/lambda/functions/consenting-person/BucketItemMetadata.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemMetadata.ts
@@ -31,37 +31,37 @@ export class BucketItemMetadata {
 
   /**
    * Get the metadata parameters for a specific single exhibit/disclosure form in s3.
-   * @param parms Will usually be specific enough to identify a specific object in s3, but may indicate
+   * @param metadata Will usually be specific enough to identify a specific object in s3, but may indicate
    * the original single exhibit/disclosure form AND all of its corrections. If the latter is the case, the metadata for
    * the most recent correction is returned.
    * @returns The s3 object key of the found item recomposed into a javascript object
    */
-  public getLatest = async (parms:BucketItemMetadataParms|string): Promise<BucketItemMetadataParms|undefined> => {
+  public getLatest = async (metadata:BucketItemMetadataParms|string): Promise<BucketItemMetadataParms|undefined> => {
     const { bucket } = this;
-    if(typeof parms == 'string') {
+    if(typeof metadata == 'string') {
       // metadata is in the form of an s3 object key, so convert it to a metadata object.
-      parms = BucketItemMetadata.fromBucketObjectKey(parms);
+      metadata = BucketItemMetadata.fromBucketObjectKey(metadata);
     }
 
-    const { consenterEmail, itemType, entityId, affiliateEmail } = parms;
+    const { consenterEmail, itemType, entityId, affiliateEmail } = metadata;
     
     if( ! consenterEmail) {
-      console.log(`Invalid parameters for ${itemType} form lookup in s3, consenterEmail missing: ${JSON.stringify(parms, null, 2)}`);
+      console.log(`Invalid parameters for ${itemType} form lookup in s3, consenterEmail missing: ${JSON.stringify(metadata, null, 2)}`);
       return undefined;
     }
     
     if( ! entityId) {
-      console.log(`Invalid parameters for ${itemType} form lookup in s3, entity_id missing: ${JSON.stringify(parms, null, 2)}`);
+      console.log(`Invalid parameters for ${itemType} form lookup in s3, entity_id missing: ${JSON.stringify(metadata, null, 2)}`);
       return undefined;
     }
 
     if( ! affiliateEmail) {
-      console.log(`Invalid parameters for ${itemType} form lookup in s3, affiliateEmail missing: ${JSON.stringify(parms, null, 2)}`);
+      console.log(`Invalid parameters for ${itemType} form lookup in s3, affiliateEmail missing: ${JSON.stringify(metadata, null, 2)}`);
       return undefined;
     }
 
     // Get all bucket items for the consenter of the specified type (exhibit or disclosure)
-    const output = await bucket.listMetadata(parms);
+    const output = await bucket.listMetadata(metadata);
     const { items } = output;
     return BucketItemMetadata.getLatestFrom(items, itemType);
   }

--- a/lib/lambda/functions/consenting-person/BucketItemMetadata.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemMetadata.ts
@@ -1,3 +1,4 @@
+import { log } from "../../Utils";
 import { BucketItem } from "./BucketItem";
 
 export const ExhibitFormsBucketEnvironmentVariableName = 'EXHIBIT_FORMS_BUCKET_NAME';
@@ -47,17 +48,17 @@ export class BucketItemMetadata {
     const { consenterEmail, itemType, entityId, affiliateEmail } = metadata;
     
     if( ! consenterEmail) {
-      console.log(`Invalid parameters for ${itemType} form lookup in s3, consenterEmail missing: ${JSON.stringify(metadata, null, 2)}`);
+      log(metadata, `Invalid parameters for ${itemType} form lookup in s3, consenterEmail missing`);
       return undefined;
     }
     
     if( ! entityId && itemType != CORRECTION_FORM) {
-      console.log(`Invalid parameters for ${itemType} form lookup in s3, entity_id missing: ${JSON.stringify(metadata, null, 2)}`);
+      log(metadata, `Invalid parameters for ${itemType} form lookup in s3, entity_id missing`);
       return undefined;
     }
 
     if( ! affiliateEmail && itemType != CORRECTION_FORM) {
-      console.log(`Invalid parameters for ${itemType} form lookup in s3, affiliateEmail missing: ${JSON.stringify(metadata, null, 2)}`);
+      log(metadata, `Invalid parameters for ${itemType} form lookup in s3, affiliateEmail missing`);
       return undefined;
     }
 

--- a/lib/lambda/functions/consenting-person/BucketItemTag.ts
+++ b/lib/lambda/functions/consenting-person/BucketItemTag.ts
@@ -31,8 +31,8 @@ export class TagInspector {
       const { fromBucketObjectKey } = BucketItemMetadata;
       const metadata = fromBucketObjectKey(s3Path);
       let { entityId, consenterEmail, affiliateEmail, correction, savedDate, itemType } = metadata;
-      const prefix = JSON.stringify({ consenterEmail, entityId, affiliateEmail });
-      console.log(`Checking tags for items under prefix: ${prefix}`);
+      const prefix = { consenterEmail, entityId, affiliateEmail };
+      log(prefix, `Checking tags for items under prefix`);
 
       // Query the bucket for every item under the specific /consenter/entityId/affiliate "subdirectory"
       const inventory = await BucketInventory.getInstance(consenterEmail!, entityId);
@@ -40,13 +40,13 @@ export class TagInspector {
 
       // The results should NEVER be empty, but accomodate anyway. 
       if(allMetadata.length == 0) {
-        console.log(`Query against bucket returned no object keys under prefix: ${prefix}`);
+        log(prefix, `Query against bucket returned no object keys under prefix`);
         return;
       }
 
       // Refine the results if possible
       if(savedDate) {
-        allMetadata = allMetadata.filter(m => (m.savedDate ?? new Date()).toISOString() == savedDate.toISOString() )
+        allMetadata = allMetadata.filter(m => (m.savedDate ?? new Date()).toISOString() == savedDate!.toISOString() )
       }
       itemType = _itemType ?? itemType;
       if(itemType) {
@@ -64,13 +64,13 @@ export class TagInspector {
         const getTag = metadata.getTag ?? (async () => undefined );
         const tagValue = await getTag(tagName);
         if(tagValue) {
-          console.log(`Tag found ${tagName} = ${tagValue} under prefix: ${prefix}`);
+          log(prefix, `Tag found ${tagName} = ${tagValue} under prefix`);
           return tagValue;
         }
       }
 
       // Tag being sought was found for none of the items - hence no disclosure request was sent.
-      console.log(`No bucket item tagging found for items under prefix: ${prefix}`);
+      log(prefix, `No bucket item tagging found for items under prefix`);
       return;
     }
     catch(e) {
@@ -121,6 +121,6 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_BUCKET_ITEM_TAG_INSPECTOR') {
 
     const tagInspector = new TagInspector(Tags.DISCLOSED);
     const tagValue = await tagInspector.findTagAmongAffiliateItems(s3Path);
-    console.log(`${Tags.DISCLOSED} = ${tagValue}`);
+    log(`${Tags.DISCLOSED} = ${tagValue}`);
   })();
 }

--- a/lib/lambda/functions/consenting-person/ConsentingPerson.test.ts
+++ b/lib/lambda/functions/consenting-person/ConsentingPerson.test.ts
@@ -5,7 +5,7 @@ const exhibitEmailMock = jest.mock('../../functions/consenting-person/ExhibitEma
   return ExhibitEmailMock();
 });
 
-const consenterBucketItemsMock = jest.mock('../../functions/consenting-person/BucketItemExhibitForms.ts', () => {
+const consenterBucketItemsMock = jest.mock('../../functions/consenting-person/BucketItemExhibitForm.ts', () => {
   return ExhibitFormBucketItemsMock();
 });
 

--- a/lib/lambda/functions/consenting-person/ConsentingPerson.ts
+++ b/lib/lambda/functions/consenting-person/ConsentingPerson.ts
@@ -334,7 +334,7 @@ export const rescindConsent = async (email:string): Promise<LambdaProxyIntegrati
 };
 
 /**
- * Correct consent.
+ * Correct consenter details.
  * @param parameters 
  * @returns 
  */

--- a/lib/lambda/functions/consenting-person/Correction.ts
+++ b/lib/lambda/functions/consenting-person/Correction.ts
@@ -10,6 +10,7 @@ import { BucketInventory } from "./BucketInventory";
 import { scheduleExhibitFormPurgeFromDatabase } from "./ConsentingPerson";
 import { ConsenterCorrectionEmail } from "./CorrectionFormEmail";
 import { ExhibitFormsBucketEnvironmentVariableName } from "./BucketItemMetadata";
+import { error, log } from "../../Utils";
 
 /**
  * This class performs modifications to a consenting person that affect email and/or phone. In the case 
@@ -38,7 +39,7 @@ export class ConsentingPersonToCorrect {
        */
       const consenter = await ConsenterCrud(this.correctable).read({ convertDates:false } as ReadParms) as Consenter|null;
       if( ! consenter) {
-        console.error(`Error: Lookup for consenter failed: ${JSON.stringify(this.correctable, null, 2)}`);
+        error(this.correctable, 'Lookup for consenter failed');
         return false;
       }
       this.correctable = consenter;
@@ -139,7 +140,7 @@ export class ConsentingPersonToCorrect {
     else {
       if( ! newNameOrTitle()) {
         // Huh? If neither the email, phone, name or title has changed, then there ARE NO changes.
-        console.log(`INVALID STATE: Correction triggered for ${email}, but no changes detected.`);
+        log(`INVALID STATE: Correction triggered for ${email}, but no changes detected.`);
         return false;
       }
 
@@ -286,7 +287,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_CONSENTER_CORRECTION') {
       email: 'cp2@warhen.work'
     } as Consenter).correct(_corrected);
 
-    console.log('Update complete.');
+    log('Update complete.');
   })();
 
 }

--- a/lib/lambda/functions/consenting-person/Correction.ts
+++ b/lib/lambda/functions/consenting-person/Correction.ts
@@ -45,21 +45,6 @@ export class ConsentingPersonToCorrect {
 
     // Possible cognito changes first:
     if(newEmail() || newPhone()) {
-      /**
-       * Update the phone_number attributes of a user in the userpool. This requires that it is
-       * configured to be mutable.
-       * 
-       * and/or..
-       * 
-       * Create a new user account with the new email and delete the old user account.
-       * 
-       * NOTE: Modification of the email address attributes is not appropriate here (even if it was mutable)
-       * because this will trigger an automatic email to the new email address with a verification code and 
-       * the email of the user will be switched to unverified. Since the user is already confirmed, and there 
-       * is no way to demote a user as unconfirmed using the SDK, the hosted UI verification prompt will not 
-       * appear during a log in attempt, and unconventional workarounds with the preauthentication lambda 
-       * trigger, flags, and redirects at the app dashboard screen would be necessary to make it work)
-       */
       const original = { email: { propname:'email', value:email } } as CognitoStandardAttributes;
       const updated = { email: { propname:'email', value:new_email } } as CognitoStandardAttributes;
       if(newPhone()) {
@@ -73,6 +58,17 @@ export class ConsentingPersonToCorrect {
 
       const userAccount = await UserAccount.getInstance(original, Roles.CONSENTING_PERSON);
       if(newEmail()) {
+        /**
+          * Create a new user account with the new email and delete the old user account.
+          * 
+          * NOTE: Modification of the email address attributes is not appropriate here (even if it was mutable)
+          * because this will trigger an automatic email to the new email address with a verification code and 
+          * the email of the user will be switched to unverified. Since the user is already confirmed, and there 
+          * is no way to demote a user as unconfirmed using the SDK, the hosted UI verification prompt will not 
+          * appear during a log in attempt, and unconventional workarounds with the preauthentication lambda 
+          * trigger, flags, and redirects at the app dashboard screen would be necessary to make it work)
+         */
+
         // Create a new user account in cognito and delete the old one.
         const userType:UserType|undefined = await userAccount.replaceWith(updated);
 

--- a/lib/lambda/functions/consenting-person/Correction.ts
+++ b/lib/lambda/functions/consenting-person/Correction.ts
@@ -129,7 +129,7 @@ export class ConsentingPersonToCorrect {
         }
 
         // Pass on any updates to the consenter to the corresponding database record.
-        await ConsenterCrud(corrected).update(correctable);
+        await ConsenterCrud(corrected).update(correctable, true);
       }
     }
     else {
@@ -139,7 +139,7 @@ export class ConsentingPersonToCorrect {
         return false;
       }
       // Pass on any updates to the consenter to the corresponding database record.
-      await ConsenterCrud(corrected).update(correctable);
+      await ConsenterCrud(corrected).update(correctable, true);
     }
 
     // Create a correction pdf form and email it to the reps of any entities that are indicated.

--- a/lib/lambda/functions/consenting-person/CorrectionFormEmail.ts
+++ b/lib/lambda/functions/consenting-person/CorrectionFormEmail.ts
@@ -5,7 +5,6 @@ import { Consenter, Roles, User, YN } from "../../_lib/dao/entity";
 import { EmailParms, sendEmail } from "../../_lib/EmailWithAttachments";
 import { CorrectionForm } from "../../_lib/pdf/CorrectionForm";
 import { PdfForm } from "../../_lib/pdf/PdfForm";
-import { log } from '../../Utils';
 
 /**
  * This class represents an email that is sent to the representatives of an entity to inform them of a
@@ -43,12 +42,8 @@ export class ConsenterCorrectionEmail {
       return (user.role == Roles.RE_AUTH_IND && user.active == YN.Yes) ? user.email : undefined
     }).filter(email => email != undefined && email != firstAI.email) as string[];
 
-    // Log what's about to happen
-    console.log(`Sending consenter correction email: ${JSON.stringify({
-      to: firstAI.email, cc: cc.join(', '), bcc: bcc.join(', ')
-    }, null, 2)}`);
-
     // Send the email
+    console.log(`Sending consenter correction email to entity: ${entity_id}`);
     return sendEmail({
       subject: `ETT Consenter Correction Notification`,
       from: `noreply@${context.ETT_DOMAIN}`,

--- a/lib/lambda/functions/consenting-person/CorrectionFormEmail.ts
+++ b/lib/lambda/functions/consenting-person/CorrectionFormEmail.ts
@@ -1,0 +1,105 @@
+import * as ctx from '../../../../contexts/context.json';
+import { IContext } from "../../../../contexts/IContext";
+import { UserCrud } from "../../_lib/dao/dao-user";
+import { Consenter, Roles, User, YN } from "../../_lib/dao/entity";
+import { EmailParms, sendEmail } from "../../_lib/EmailWithAttachments";
+import { CorrectionForm } from "../../_lib/pdf/CorrectionForm";
+import { PdfForm } from "../../_lib/pdf/PdfForm";
+import { log } from '../../Utils';
+
+/**
+ * This class represents an email that is sent to the representatives of an entity to inform them of a
+ * correction a consenting individual has made to their name and/or contact details.
+ */
+export class ConsenterCorrectionEmail {
+  private oldConsenter:Consenter;
+  private correctionForm:CorrectionForm;
+
+  constructor(oldConsenter:Consenter, newConsenter:Consenter) {
+    this.oldConsenter = oldConsenter;
+    this.correctionForm = new CorrectionForm(oldConsenter, newConsenter);
+  }
+
+  public sendToEntity = async (entity_id:string):Promise<boolean> => {
+    const context:IContext = <IContext>ctx;
+    const { oldConsenter: {firstname, middlename, lastname }, correctionForm } = this;
+    const fullname = PdfForm.fullName(firstname, middlename, lastname);
+    const users = (await UserCrud({ entity_id } as User).read() ?? []) as User[];
+
+    // Get the first AI of the entity as the "to" addressee
+    const firstAI = users.find(user => user.active == YN.Yes && user.role == Roles.RE_AUTH_IND);
+    if( ! firstAI) {
+      console.warn(`Could not find an active authorized individual for entity: ${entity_id}`);
+      return false;
+    }
+
+    // Get the admin of the entity as the bcc addressee.
+    const bcc = users.map(user => { 
+      return (user.role == Roles.RE_ADMIN && user.active == YN.Yes) ? user.email : undefined
+    }).filter(email => email != undefined) as string[];
+
+    // Get the other AI of the entity as a cc addressee.
+    const cc = users.map(user => {
+      return (user.role == Roles.RE_AUTH_IND && user.active == YN.Yes) ? user.email : undefined
+    }).filter(email => email != undefined && email != firstAI.email) as string[];
+
+    // Log what's about to happen
+    console.log(`Sending consenter correction email: ${JSON.stringify({
+      to: firstAI.email, cc: cc.join(', '), bcc: bcc.join(', ')
+    }, null, 2)}`);
+
+    // Send the email
+    return sendEmail({
+      subject: `ETT Consenter Correction Notification`,
+      from: `noreply@${context.ETT_DOMAIN}`,
+      message: `Please find enclosed a correction form listing modifications that consenting ` +
+        `individual ${fullname} has made to their name and/or contact details.`,
+      to: [ firstAI.email ], cc, bcc,
+      attachments: [
+        {
+          pdf: correctionForm,
+          name: 'consenter-correction-form.pdf',
+          description: 'consenter-correction-form.pdf'
+        }
+      ]
+    } as EmailParms);
+  }
+
+  public getCorrectionForm =():CorrectionForm => {
+    return this.correctionForm;
+  }
+}
+
+
+
+
+/**
+ * RUN MANUALLY: Modify entity_id to reflect an existing entity
+ */
+const { argv:args } = process;
+if(args.length > 2 && args[2] == 'RUN_MANUALLY_SEND_CONSENTER_CORRECTION_FORM') {
+
+  const oldConsenter = {
+    email: 'bugs@warnerbros.com',
+    firstname: 'Bugs',
+    middlename: 'Bartholomew',
+    lastname: 'Bunny',
+    phone_number: '+1234567890',
+    active: 'Y'
+  } as Consenter;
+
+  const newConsenter = {
+    email: 'bugs@warnerbros.com',
+    firstname: 'Bugs',
+    middlename: 'Cornelius',
+    lastname: 'Bunny',
+    phone_number: '+1234567890',
+    active: 'Y'
+  } as Consenter;
+
+  const entity_id = '13376a3d-12d8-40e1-8dee-8c3d099da1b2';
+
+  (async() => {
+    await new ConsenterCorrectionEmail(oldConsenter, newConsenter).sendToEntity(entity_id);
+  })();
+}

--- a/lib/lambda/functions/consenting-person/ExhibitCorrectionEmail.ts
+++ b/lib/lambda/functions/consenting-person/ExhibitCorrectionEmail.ts
@@ -112,12 +112,8 @@ export class ExhibitCorrectionEmail {
       return (user.role == Roles.RE_AUTH_IND && user.active == YN.Yes) ? user.email : undefined
     }).filter(email => email != undefined && email != firstAI.email) as string[];
 
-    // Log what's about to happen
-    console.log(`Sending exhibit form correction email to entity reps: ${JSON.stringify({
-      to: firstAI.email, cc: cc.join(', '), bcc: bcc.join(', ')
-    }, null, 2)}`);
-
     // Send the email
+    console.log(`Sending exhibit form correction email to entity reps`);
     const from = `noreply@${context.ETT_DOMAIN}`;
     return sendEmail({ subject, from, message, to: [ firstAI.email ], cc, bcc, attachments } as EmailParms);
   }

--- a/lib/lambda/functions/delayed-execution/PurgeExhibitFormFromDatabase.ts
+++ b/lib/lambda/functions/delayed-execution/PurgeExhibitFormFromDatabase.ts
@@ -2,7 +2,7 @@ import { UpdateItemCommandOutput } from "@aws-sdk/client-dynamodb";
 import { DAOFactory } from "../../_lib/dao/dao";
 import { Consenter } from "../../_lib/dao/entity";
 import { DelayedLambdaExecution, PostExecution, ScheduledLambdaInput } from "../../_lib/timer/DelayedExecution";
-import { debugLog, deepClone, log } from "../../Utils";
+import { debugLog, deepClone, log, warn } from "../../Utils";
 import { EggTimer, PeriodType } from "../../_lib/timer/EggTimer";
 import { IContext } from "../../../../contexts/IContext";
 import { DelayedExecutions } from "../../../DelayedExecution";
@@ -14,7 +14,7 @@ export const handler = async(event:ScheduledLambdaInput, context:any) => {
     debugLog({ event, context });
 
     const { consenterEmail, entity_id } = lambdaInput ?? {};
-    log(`Deleting exhibit form: ${JSON.stringify({ consenterEmail, entity_id })}`);
+    log({ consenterEmail, entity_id }, `Deleting exhibit form`);
 
     const response = await deleteExhibitForm(consenterEmail, entity_id) as UpdateItemCommandOutput;
     if(response) {
@@ -59,7 +59,7 @@ export const deleteExhibitForm = async (consenterEmail:string, entity_id:string)
   const remainingForms = newConsenterInfo.exhibit_forms ?? [];
 
   if(remainingForms.length == startingFormCount) {
-    console.warn(`Attempt to delete exhibit form that does not exist ${JSON.stringify({ consenterEmail, entity_id })}`);
+    warn({ consenterEmail, entity_id }, `Attempt to delete exhibit form that does not exist`);
     return;
   }
 
@@ -99,7 +99,7 @@ if(args.length > 3 && args[2] == 'RUN_MANUALLY_PURGE_EXHIBIT_FORM_FROM_DATABASE'
         await delayedTestExecution.startCountdown(timer, `Dynamodb exhibit form purge (TESTING)`);
         break;
       default:
-        console.log(`Unknown task "${task}" specified!`);
+        log(`Unknown task "${task}" specified!`);
         break;
     }
   })();

--- a/lib/lambda/functions/delayed-execution/PurgeExhibitFormFromDatabase.ts
+++ b/lib/lambda/functions/delayed-execution/PurgeExhibitFormFromDatabase.ts
@@ -47,6 +47,14 @@ export const deleteExhibitForm = async (consenterEmail:string, entity_id:string)
       return ef.entity_id != entity_id;
     });
     newConsenterInfo.exhibit_forms = filtered;
+    /**
+     * TODO: If the user saves the exhibit form, the corresponding database content is removed immediately,
+     * in which case, this operation will purge nothing from the database and end as a non-action result.
+     * However, if after saving, the user submits another exhibit form for the same enitity, this new
+     * database entry should get a new timer, but this existing timer execution will purge it BEFORE its time.
+     * So, to account for this, extend the filter above so that removes any exhibit form whose created_date
+     * value indicates it was saved LATER than what would have been this executions egg timer starting point.
+     */
   }
   const remainingForms = newConsenterInfo.exhibit_forms ?? [];
 

--- a/lib/lambda/functions/delayed-execution/SendDisclosureRequestReminder.ts
+++ b/lib/lambda/functions/delayed-execution/SendDisclosureRequestReminder.ts
@@ -6,7 +6,7 @@ import { debugLog, log } from "../../Utils";
 import { DisclosureEmailParms, DisclosureRequestReminderEmail } from "../authorized-individual/DisclosureRequestEmail";
 import { BucketInventory } from "../consenting-person/BucketInventory";
 import { BucketItemMetadata, ExhibitFormsBucketEnvironmentVariableName, ItemType } from "../consenting-person/BucketItemMetadata";
-import { purgeFormFromBucket } from "./PurgeExhibitFormFromBucket";
+import { purgeFormFromBucket, purgeCorrectionForms } from "./PurgeExhibitFormFromBucket";
 import { getTestItem } from "./TestBucketItem";
 
 export type DisclosureRequestReminderLambdaParms = {
@@ -52,7 +52,9 @@ export const handler = async(event:ScheduledLambdaInput, context:any) => {
     if(purgeForms) {
       await purgeFormFromBucket(EXHIBIT, s3ObjectKeyForExhibitForm);
 
-      await purgeFormFromBucket(DISCLOSURE, s3ObjectKeyForDisclosureForm);      
+      await purgeFormFromBucket(DISCLOSURE, s3ObjectKeyForDisclosureForm);
+           
+      await purgeCorrectionForms(s3ObjectKeyForExhibitForm);
     }
   }
   catch(e:any) {    

--- a/lib/lambda/functions/delayed-execution/TestBucketItem.ts
+++ b/lib/lambda/functions/delayed-execution/TestBucketItem.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { IContext } from "../../../../contexts/IContext";
 import { AffiliateTypes, Consenter, YN } from "../../_lib/dao/entity";
-import { BucketItem } from "../consenting-person/BucketItem";
 import { BucketDisclosureForm } from "../consenting-person/BucketItemDisclosureForm";
 import { BucketExhibitForm } from "../consenting-person/BucketItemExhibitForm";
 import { ExhibitFormsBucketEnvironmentVariableName, ItemType } from "../consenting-person/BucketItemMetadata";
@@ -57,15 +56,13 @@ export const getTestItem = async () => {
     const affiliateEmail = affiliates[0].email;
     switch(itemType) {
       case EXHIBIT:
-        return await new BucketExhibitForm(
-          new BucketItem(consenter),
-          { itemType:EXHIBIT, entityId, affiliateEmail, savedDate:now }
-        ).add();
+        return await new BucketExhibitForm({ 
+          consenterEmail:consenter.email, itemType:EXHIBIT, entityId, affiliateEmail, savedDate:now 
+        }).add(consenter);
       case DISCLOSURE:
         return await new BucketDisclosureForm({
-          bucket: new BucketItem(consenter),
-          metadata: { itemType:DISCLOSURE, entityId, affiliateEmail, savedDate:now }
-        }).add();
+          metadata: { consenterEmail:consenter.email, itemType:DISCLOSURE, entityId, affiliateEmail, savedDate:now }
+        }).add(consenter);
       }      
   }
 

--- a/lib/lambda/functions/delayed-execution/TestBucketItem.ts
+++ b/lib/lambda/functions/delayed-execution/TestBucketItem.ts
@@ -1,11 +1,12 @@
 import { v4 as uuidv4 } from 'uuid';
 import { IContext } from "../../../../contexts/IContext";
 import { AffiliateTypes, Consenter, YN } from "../../_lib/dao/entity";
+import { BucketCorrectionForm } from '../consenting-person/BucketItemCorrectionForm';
 import { BucketDisclosureForm } from "../consenting-person/BucketItemDisclosureForm";
 import { BucketExhibitForm } from "../consenting-person/BucketItemExhibitForm";
 import { ExhibitFormsBucketEnvironmentVariableName, ItemType } from "../consenting-person/BucketItemMetadata";
 
-export const getConsenter = (dummyDate:string) => {
+export const getConsenter = (dummyDate:string=new Date().toISOString()) => {
   return {
     email: 'cp1@warhen.work',
     active: YN.Yes,
@@ -37,7 +38,7 @@ export const getTestItem = async () => {
   const now = new Date();
   const dummyDate = new Date().toISOString();
   const consenter = getConsenter(dummyDate);
-  const { EXHIBIT, DISCLOSURE } = ItemType;
+  const { EXHIBIT, DISCLOSURE, CORRECTION_FORM } = ItemType;
   const context:IContext = await require('../../../../contexts/context.json');
   const { STACK_ID, REGION, TAGS: { Landscape } } = context;
   const prefix = `${STACK_ID}-${Landscape}`;
@@ -63,6 +64,17 @@ export const getTestItem = async () => {
         return await new BucketDisclosureForm({
           metadata: { consenterEmail:consenter.email, itemType:DISCLOSURE, entityId, affiliateEmail, savedDate:now }
         }).add(consenter);
+      case CORRECTION_FORM:
+        const oldConsenter = getConsenter(dummyDate);
+        const newConsenter = getConsenter();
+        const { firstname, middlename, lastname, phone_number, title } = oldConsenter;
+        newConsenter.firstname = `${firstname} (corrected)`;
+        newConsenter.middlename = `${middlename} (corrected)`;
+        newConsenter.lastname = `${lastname} (corrected)`;
+        newConsenter.phone_number = `${phone_number} (corrected)`;
+        newConsenter.title = `${title} (corrected)`;
+        const form = BucketCorrectionForm.getInstanceForCreation(newConsenter, oldConsenter);
+        return await form.add();
       }      
   }
 

--- a/lib/lambda/functions/re-admin/ReAdminUser.ts
+++ b/lib/lambda/functions/re-admin/ReAdminUser.ts
@@ -205,7 +205,7 @@ export const createEntity = async (entity:Entity, reAdmin?:User):Promise<LambdaP
 export const updateReAdminInvitationWithNewEntity = async (reAdminEmail:string, new_entity_id:string) => {
   // Get the "homeless" invitation for the RE_ADMIN. This will be found by email hanging out in the waiting room.
   // There may be more than one if a SYS_ADMIN invited the RE_ADMIN again before the original invitation is accepted.
-  console.log(`updateReAdminInvitationWithNewEntity: reAdminEmail:${reAdminEmail}, new_entity_id:${new_entity_id}`);
+  log(`updateReAdminInvitationWithNewEntity: reAdminEmail:${reAdminEmail}, new_entity_id:${new_entity_id}`);
   let daoInvitation = DAOFactory.getInstance({ 
     DAOType: 'invitation', 
     Payload: { email:reAdminEmail, entity_id:ENTITY_WAITING_ROOM } as Invitation
@@ -231,7 +231,7 @@ export const updateReAdminInvitationWithNewEntity = async (reAdminEmail:string, 
  * @param new_entity_id 
  */
 const migrateReAdminUserFromWaitingRoomToNewEntity = async (reAdminEmail:string, new_entity_id:string) => {
-  console.log(`updateReAdminUserRecordWithNewEntity: reAdminEmail:${reAdminEmail}, new_entity_id:${new_entity_id}`);
+  log(`updateReAdminUserRecordWithNewEntity: reAdminEmail:${reAdminEmail}, new_entity_id:${new_entity_id}`);
   const daoUser = DAOFactory.getInstance({
     DAOType: 'user',
     Payload: { email:reAdminEmail, entity_id:new_entity_id } as User
@@ -567,7 +567,7 @@ if(args.length > 2 && args[2] == 'RUN_MANUALLY_RE_ADMIN') {
 
     return handler(_event);
   }).then(() => {
-    console.log(`${task} complete.`)
+    log(`${task} complete.`)
   })
   .catch((reason) => {
     console.error(reason);

--- a/lib/lambda/functions/signup/ConsenterRegistration.ts
+++ b/lib/lambda/functions/signup/ConsenterRegistration.ts
@@ -1,7 +1,7 @@
 import { AbstractRoleApi, IncomingPayload, LambdaProxyIntegrationResponse } from "../../../role/AbstractRole";
 import { ConsenterCrud } from "../../_lib/dao/dao-consenter";
 import { Consenter, YN } from "../../_lib/dao/entity";
-import { debugLog, errorResponse, invalidResponse, log, okResponse } from "../../Utils";
+import { debugLog, error, errorResponse, invalidResponse, log, okResponse } from "../../Utils";
 
 /**
  * Handles the public steps of registration for consenting individual
@@ -56,7 +56,7 @@ export const handler = async(event:any):Promise<LambdaProxyIntegrationResponse> 
     return okResponse(`${email} created`);
   }
   catch(e:any) {
-    console.log(e);
+    error(e);
     return errorResponse(e.message);
   }
 }

--- a/lib/lambda/functions/signup/EntityAcknowledgement.ts
+++ b/lib/lambda/functions/signup/EntityAcknowledgement.ts
@@ -1,6 +1,6 @@
 import { Invitation } from "../../_lib/dao/entity";
 import { Registration } from "../../_lib/invitation/Registration";
-import { debugLog, errorResponse, invalidResponse, lookupCloudfrontDomain, okResponse, unauthorizedResponse } from "../../Utils";
+import { debugLog, error, errorResponse, invalidResponse, lookupCloudfrontDomain, okResponse, unauthorizedResponse } from "../../Utils";
 
 export enum Task {
   LOOKUP_INVITATION = 'lookup-invitation',
@@ -51,7 +51,7 @@ export const handler = async(event:any) => {
     return errorResponse('Error: Acknowledgement failed!');    
   }
   catch(e:any) {
-    console.log(e);
+    error(e);
     return errorResponse(e.message);
   }
 }

--- a/lib/lambda/functions/signup/EntityRegistration.ts
+++ b/lib/lambda/functions/signup/EntityRegistration.ts
@@ -3,7 +3,7 @@ import { DAOFactory } from "../../_lib/dao/dao";
 import { ENTITY_WAITING_ROOM } from "../../_lib/dao/dao-entity";
 import { Entity, Invitation, Roles, User, YN } from "../../_lib/dao/entity";
 import { Registration } from "../../_lib/invitation/Registration";
-import { debugLog, errorResponse, invalidResponse, lookupCloudfrontDomain, lookupSingleActiveEntity, okResponse, unauthorizedResponse } from "../../Utils";
+import { debugLog, error, errorResponse, invalidResponse, lookupCloudfrontDomain, lookupSingleActiveEntity, okResponse, unauthorizedResponse } from "../../Utils";
 import { demolishEntity } from "../authorized-individual/AuthorizedIndividual";
 
 export enum Task {
@@ -127,7 +127,7 @@ export const handler = async(event:any):Promise<LambdaProxyIntegrationResponse> 
     throw new Error('Error: Unreachable code');
   }
   catch(e:any) {
-    console.log(e);
+    error(e);
     return errorResponse(e.message);
   }
 }

--- a/lib/lambda/functions/sys-admin/SysAdminUser.ts
+++ b/lib/lambda/functions/sys-admin/SysAdminUser.ts
@@ -7,7 +7,7 @@ import { DAOEntity, DAOFactory } from '../../_lib/dao/dao';
 import { ENTITY_WAITING_ROOM } from '../../_lib/dao/dao-entity';
 import { Config, ConfigNames, Entity, EntityFields, Role, Roles, YN } from '../../_lib/dao/entity';
 import { SignupLink } from '../../_lib/invitation/SignupLink';
-import { debugLog, errorResponse, invalidResponse, log, lookupCloudfrontDomain, okResponse } from "../../Utils";
+import { debugLog, error, errorResponse, invalidResponse, log, lookupCloudfrontDomain, okResponse } from "../../Utils";
 import { Task as ReAdminTasks, createEntity, createEntityAndInviteUsers, deactivateEntity, inviteUser, inviteUsers, lookupEntity, updateEntity } from '../re-admin/ReAdminUser';
 import { DynamoDbTableOutput } from './DynamoDbTableOutput';
 import { HtmlTableView } from './view/HtmlTableView';
@@ -248,10 +248,10 @@ if(args.length > 3 && args[2] == 'RUN_MANUALLY_SYS_ADMIN') {
       }
 
       const retval = await handler(_event);
-      console.log(`${task} complete. Returned value: ${JSON.stringify(retval, null, 2)}`);
+      log(retval, `${task} complete. Returned value`);
     }
     catch(e) {
-      console.error(e);
+      error(e);
     }
   })(); 
 }


### PR DESCRIPTION
This feature extends the prior feature for a consenting individual to "correct" their account details by adding the related email notification activity. Details include:

- A new Correction form pdf file that details the changes made by the consenter
- An email notification to entity reps that attaches the correction form.
- Backend logic that saves the correction form to the s3 bucket.
- Modification to disclosure requests and reminders that attaches the correction form if deemed necessary.
