### PR TITLE
Rescind consent

### DIFF
--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -2589,6 +2589,7 @@
     const rescindConsent = async () => {
       const { email } = IDJwtCookie.getUser() ?? {};
       await doConsentTask('rescind-consent', { email });
+      signOut();
     }
 
     /**


### PR DESCRIPTION
This feature extends the existing rescind feature so that in addition to deactivating the consenting database record and appending the rescind timestamp to it, it also:

- Purges the database record for the consenter of all saved exhibit forms
- Removes the consenter from the cognito userpool
- Logs the user out of the ETT app.

NOTE: Any exhibit forms for the consenter will eventually be purged either of the two event bridge rules set up to do so.