### PR TITLE
Config api

### DIFF
--- a/bin/EttApp.ts
+++ b/bin/EttApp.ts
@@ -21,7 +21,9 @@ const context:IContext = <IContext>ctx;
 
 const app = new App();
 app.node.setContext('stack-parms', context);
-const { STACK_ID, ACCOUNT:account, REGION:region, TAGS: { Function, Landscape, Service }, SCENARIO:scenario } = context;
+const { 
+  STACK_ID, ACCOUNT:account, REGION:region, TAGS: { Function, Landscape, Service }, SCENARIO:scenario, REDIRECT_PATH_WEBSITE
+} = context;
 const stackName = `${STACK_ID}-${Landscape}`;
 
 const stackProps: StackProps = {
@@ -106,7 +108,7 @@ const buildAll = () => {
     userPoolName: cognito.getUserPoolName(),  
     userPoolDomain: cognito.getUserPoolDomain(),  
     cloudfrontDomain: cloudfront.getDistributionDomainName(),
-    redirectPath: 'index.html',
+    redirectPath: REDIRECT_PATH_WEBSITE,
     landscape: Landscape,
     exhibitFormsBucket: exhibitFormsBucket,
     databaseExhibitFormPurgeLambdaArn: delayedExecutionLambdas.databaseExhibitFormPurgeLambda.functionArn,

--- a/bin/EttApp.ts
+++ b/bin/EttApp.ts
@@ -16,6 +16,7 @@ import { StaticSiteConstructParms } from '../lib/StaticSite';
 import { StaticSiteBootstrapConstruct } from '../lib/StaticSiteBootstrap';
 import { StaticSiteWebsiteConstruct } from '../lib/StaticSiteWebsite';
 import { Roles } from '../lib/lambda/_lib/dao/entity';
+import { ViewerRequestParametersConstruct } from '../lib/lambda/functions/cloudfront/ViewerRequestParameters';
 
 const context:IContext = <IContext>ctx;
 
@@ -139,6 +140,15 @@ const buildAll = () => {
       ]
     } as StaticSiteConstructParms
   };
+
+  const parameters = new ViewerRequestParametersConstruct(
+    cloudfront, 'ViewerRequestParameters', 
+    { 
+      bootstrap: getStaticSiteParameters(bootstrapBucket), 
+      website: getStaticSiteParameters(websiteBucket),
+      context 
+    }
+  );
   
   // Set up the event, lambda and associated policies for modification of html files as they are uploaded 
   // to the bootstrap bucket and ensure that static html content is uploaded to it.

--- a/contexts/IContext.ts
+++ b/contexts/IContext.ts
@@ -8,6 +8,8 @@ export interface IContext {
   ETT_DOMAIN?: string;
   CLOUDFRONT_DOMAIN?: string;
   CLOUDFRONT_CERTIFICATE?: string;
+  REDIRECT_PATH_WEBSITE:string;
+  REDIRECT_PATH_BOOTSTRAP:string;
   CONFIG: CONFIG;
   TAGS:     Tags;
 }

--- a/contexts/context.json
+++ b/contexts/context.json
@@ -4,6 +4,8 @@
   "ACCOUNT": "037860335094",
   "REGION": "us-east-2",
   "ETT_DOMAIN": "warhen.work",
+  "REDIRECT_PATH_BOOTSTRAP": "bootstrap/index.htm",
+  "REDIRECT_PATH_WEBSITE": "index.html",
   "CONFIG": {
     "useDatabase": true,
     "configs": [
@@ -72,6 +74,6 @@
   "TAGS": {
     "Service": "client",
     "Function": "ett",
-    "Landscape": "dev"
+    "Landscape": "warren"
   }
 }

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -1017,15 +1017,15 @@
                   <div id="divAffiliateConstraint" style="overflow: auto; border-top:1px solid #cccccc; padding-top:15px;">
                     <form id="formAffiliateConstraint" name="formAffiliateConstraint">
                       <label class="containerRDO">Current Employer(s) only
-                        <input type="radio" name="affiliateConstraint" value="CURRENT">
+                        <input type="radio" name="affiliateConstraint" value="current">
                         <span class="checkmark"></span>
                       </label>
                       <label class="containerRDO">Other affiliates & Prior Employer(s)
-                        <input type="radio" name="affiliateConstraint" value="OTHER">
+                        <input type="radio" name="affiliateConstraint" value="other">
                         <span class="checkmark"></span>
                       </label>
                       <label class="containerRDO">Both - Any of the above
-                        <input type="radio" name="affiliateConstraint" value="BOTH" checked="checked">
+                        <input type="radio" name="affiliateConstraint" value="both" checked="checked">
                         <span class="checkmark"></span>
                       </label>
                     </form>
@@ -1738,7 +1738,7 @@
     let RefreshJwtCookie;
 
     const getSelectedRole = () => {
-      if(document.location.pathname.startsWith('/bootstrap/consenter/exhibits/')) {
+      if(document.location.pathname.startsWith('/bootstrap/consenting/add-exhibit-form/')) {
         return 'CONSENTING_PERSON';
       }
       let role = new URL(document.location.href).searchParams.get('selected_role');
@@ -1768,7 +1768,7 @@
 
     const ExhibitsPath = () => {
       const isMatch = () => {
-        const exhibits = document.location.pathname.startsWith('/bootstrap/consenter/exhibits/');
+        const exhibits = document.location.pathname.startsWith('/bootstrap/consenting/add-exhibit-form/');
         return selected_role == 'CONSENTING_PERSON' && exhibits;
       }
       const getRedirectUri = () => {
@@ -2502,16 +2502,16 @@
               document.getElementById('consenter-exhibit-compose-link').click();
               const affiliateTypes = document.querySelector('select[name=org-type]').options;
               switch(exhibitsPath.getType()) {
-                case 'CURRENT':
+                case 'current':
                   affiliateTypes.namedItem('header').remove();
                   affiliateTypes.namedItem('ACADEMIC').remove();
                   affiliateTypes.namedItem('EMPLOYER_PRIOR').remove();
                   affiliateTypes.namedItem('OTHER').remove();
                   break;
-                case 'OTHER':
+                case 'other':
                   affiliateTypes.namedItem('EMPLOYER').remove();
                   break;
-                case 'BOTH': default:
+                case 'both': default:
                   break;
               }
             }

--- a/lib/Cloudfront.ts
+++ b/lib/Cloudfront.ts
@@ -29,7 +29,7 @@ export class CloudfrontConstruct extends Construct {
 
     this.constructId = constructId;
     this.context = scope.node.getContext('stack-parms');
-    const { TAGS: { Landscape:landscape }, STACK_ID } = this.context;
+    const { context: { TAGS: { Landscape:landscape }, STACK_ID, REDIRECT_PATH_WEBSITE } } = this;
     const  defaultBehavior = { 
       origin: new HttpOrigin('dummy-origin.com', { originId: 'dummy-origin' })
     }
@@ -37,7 +37,7 @@ export class CloudfrontConstruct extends Construct {
     this.distribution = new Distribution(this, 'Distribution', {
       defaultBehavior,
       comment: `${STACK_ID}-${landscape}-distribution`,
-      defaultRootObject: 'index.html',
+      defaultRootObject: REDIRECT_PATH_WEBSITE,
       logBucket: new Bucket(this, 'DistributionLogsBucket', {
         removalPolicy: RemovalPolicy.DESTROY,    
         autoDeleteObjects: true,
@@ -103,8 +103,8 @@ export class CloudfrontConstruct extends Construct {
     cfnDist.addPropertyOverride('DistributionConfig.CustomErrorResponses', [ {
       ErrorCode: 403,
       ResponseCode: 200,
-      ResponsePagePath: '/index.html',
-    } ]);
+      ResponsePagePath: `/${REDIRECT_PATH_WEBSITE}`,
+    }]);
 
   }
 

--- a/lib/CognitoUserPoolClient.ts
+++ b/lib/CognitoUserPoolClient.ts
@@ -24,7 +24,7 @@ export class EttUserPoolClient extends UserPoolClient {
   public static buildCustomScopedClient(userPool: UserPool, id: string, props: EttUserPoolClientProps): EttUserPoolClient {
     
     const context: IContext = userPool.node.getContext('stack-parms');
-    const { TAGS: {Landscape }, STACK_ID } = context;
+    const { TAGS: {Landscape }, STACK_ID, REDIRECT_PATH_BOOTSTRAP, REDIRECT_PATH_WEBSITE } = context;
     let scopes:OAuthScope[] = [ OAuthScope.EMAIL, OAuthScope.PHONE, OAuthScope.PROFILE ];
     const {customScopes, callbackDomainName, role } = props;
     if(customScopes) {
@@ -34,8 +34,10 @@ export class EttUserPoolClient extends UserPoolClient {
     /**
      * Get urls to the app location that cognito will "callback" or redirect to upon successful signin.
      */
-    const getCallbackUrls = (rootObject:string, subfolder:string=''): string[] => {
+    const getCallbackUrls = (rootPath:string): string[] => {
       let callbackUrlRoot = `https://${callbackDomainName}`;
+      const subfolder = rootPath.substring(0, rootPath.lastIndexOf('/'));
+      const rootObject = rootPath.substring(rootPath.lastIndexOf('/')+1);
       if(subfolder) {
         callbackUrlRoot = `${callbackUrlRoot}/${subfolder}`;
       }
@@ -61,8 +63,10 @@ export class EttUserPoolClient extends UserPoolClient {
     /**
      * Get urls to the app location that cognito will redirect to upon successful signout.
      */
-    const getLogoutUrls = (rootObject:string, subfolder:string=''): string[] => {
+    const getLogoutUrls = (rootPath:string): string[] => {
       let callbackUrlRoot = `https://${callbackDomainName}`;
+      const subfolder = rootPath.substring(0, rootPath.lastIndexOf('/'));
+      const rootObject = rootPath.substring(rootPath.lastIndexOf('/')+1);
       if(subfolder) {
         callbackUrlRoot = `${callbackUrlRoot}/${subfolder}`;
       }
@@ -80,11 +84,11 @@ export class EttUserPoolClient extends UserPoolClient {
       return urls;
     }
 
-    const callbackUrls = getCallbackUrls('index.htm', 'bootstrap');
-    callbackUrls.push(...getCallbackUrls('index.html'));
+    const callbackUrls = getCallbackUrls(REDIRECT_PATH_BOOTSTRAP);
+    callbackUrls.push(...getCallbackUrls(REDIRECT_PATH_WEBSITE));
 
-    const logoutUrls = getLogoutUrls('index.htm', 'bootstrap');
-    logoutUrls.push(...getLogoutUrls('index.html'));
+    const logoutUrls = getLogoutUrls(REDIRECT_PATH_BOOTSTRAP);
+    logoutUrls.push(...getLogoutUrls(REDIRECT_PATH_WEBSITE));
 
     const client = new EttUserPoolClient(userPool, id, {
       userPool,

--- a/lib/CognitoUserPoolClient.ts
+++ b/lib/CognitoUserPoolClient.ts
@@ -48,9 +48,9 @@ export class EttUserPoolClient extends UserPoolClient {
       ] as string[];
 
       if(role == Roles.CONSENTING_PERSON) {
-        urls.push(`${callbackUrlRoot}/consenter/exhibits/CURRENT/${rootObject}?action=${Actions.login}&selected_role=${role}`);        
-        urls.push(`${callbackUrlRoot}/consenter/exhibits/OTHER/${rootObject}?action=${Actions.login}&selected_role=${role}`);        
-        urls.push(`${callbackUrlRoot}/consenter/exhibits/BOTH/${rootObject}?action=${Actions.login}&selected_role=${role}`);
+        urls.push(`${callbackUrlRoot}/consenting/add-exhibit-form/current/${rootObject}?action=${Actions.login}&selected_role=${role}`);        
+        urls.push(`${callbackUrlRoot}/consenting/add-exhibit-form/other/${rootObject}?action=${Actions.login}&selected_role=${role}`);        
+        urls.push(`${callbackUrlRoot}/consenting/add-exhibit-form/both/${rootObject}?action=${Actions.login}&selected_role=${role}`);
       }
       else {
         urls.push(`${urls[1]}&task=amend`);
@@ -76,9 +76,9 @@ export class EttUserPoolClient extends UserPoolClient {
       ] as string[];
 
       if(role == Roles.CONSENTING_PERSON) {
-        urls.push(`${callbackUrlRoot}/consenter/exhibits/CURRENT/${rootObject}?action=${Actions.logout}`);
-        urls.push(`${callbackUrlRoot}/consenter/exhibits/OTHER/${rootObject}?action=${Actions.logout}`);
-        urls.push(`${callbackUrlRoot}/consenter/exhibits/BOTH/${rootObject}?action=${Actions.logout}`);
+        urls.push(`${callbackUrlRoot}/consenting/add-exhibit-form/current/${rootObject}?action=${Actions.logout}`);
+        urls.push(`${callbackUrlRoot}/consenting/add-exhibit-form/other/${rootObject}?action=${Actions.logout}`);
+        urls.push(`${callbackUrlRoot}/consenting/add-exhibit-form/both/${rootObject}?action=${Actions.logout}`);
       }
 
       return urls;

--- a/lib/StaticSite.ts
+++ b/lib/StaticSite.ts
@@ -50,7 +50,7 @@ export abstract class StaticSiteConstruct extends Construct {
    * @param parms 
    * @returns A parameter object comprising all values client apps need to authenticate and talk with the backend.
    */
-  public buildSiteParmObject = (parms: StaticSiteConstructParms, redirectPath:string):any => {
+  public static buildSiteParmObject = (parms: StaticSiteConstructParms, redirectPath:string):any => {
     let jsonObj = {
       COGNITO_DOMAIN: parms.cognitoDomain,
       USER_POOL_REGION: parms.cognitoUserpoolRegion,

--- a/lib/StaticSiteBootstrap.ts
+++ b/lib/StaticSiteBootstrap.ts
@@ -22,9 +22,10 @@ export class StaticSiteBootstrapConstruct extends StaticSiteConstruct {
   }
 
   customize(): void {
-    const { context: { ACCOUNT, TAGS: { Landscape:landscape }, STACK_ID }, constructId, parms, buildSiteParmObject } = this;
+    const { context: { ACCOUNT, TAGS: { Landscape:landscape }, STACK_ID, REDIRECT_PATH_BOOTSTRAP }, constructId, parms } = this;
+    const { buildSiteParmObject } = StaticSiteBootstrapConstruct;
     const functionName = `${STACK_ID}-${landscape}-${constructId.toLowerCase()}-injection-function`;
-    const staticParms = JSON.stringify(buildSiteParmObject(parms as StaticSiteConstructParms, 'bootstrap/index.htm'), null, 2);
+    const staticParms = JSON.stringify(buildSiteParmObject(parms as StaticSiteConstructParms, REDIRECT_PATH_BOOTSTRAP), null, 2);
     const conversionFunction = new AbstractFunction(this, 'TextConverterFunction', {
       functionName,
       description: 'Function for modifying content being loaded into the static website bucket so that \

--- a/lib/StaticSiteWebsite.ts
+++ b/lib/StaticSiteWebsite.ts
@@ -1,9 +1,9 @@
-import { Construct } from "constructs";
-import { StaticSiteConstruct, StaticSiteConstructParms } from "./StaticSite";
+import { RemovalPolicy } from "aws-cdk-lib";
 import { Effect, PolicyStatement, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
-import { RemovalPolicy } from "aws-cdk-lib";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
+import { Construct } from "constructs";
+import { StaticSiteConstruct, StaticSiteConstructParms } from "./StaticSite";
 
 /**
  * This construct is for an s3 bucket that is to host the single page app html file and related
@@ -62,11 +62,12 @@ export class StaticSiteWebsiteConstruct extends StaticSiteConstruct {
   }
 
   public setBucketDeployment(dependOn?: Construct[]): void {
-    const { parms, buildSiteParmObject } = this;
+    const { parms, context: { REDIRECT_PATH_WEBSITE } } = this;
+    const { buildSiteParmObject } = StaticSiteWebsiteConstruct;
     const deployment = new BucketDeployment(this, 'WebsiteBucketContentDeployment', {
       destinationBucket: this.getBucket(),      
       sources: [
-        Source.jsonData('SiteParameters.json', buildSiteParmObject(parms, 'index.html'))
+        Source.jsonData('SiteParameters.json', buildSiteParmObject(parms, REDIRECT_PATH_WEBSITE))
       ],
     });
 

--- a/lib/lambda/_lib/invitation/SignupLink.ts
+++ b/lib/lambda/_lib/invitation/SignupLink.ts
@@ -92,12 +92,19 @@ export class SignupLink {
   public getRegistrationLink = async (parms:RegistrationLinkParms):Promise<string|undefined> => {
     let { entity_id, registrationUri } = parms;
     return new Promise((resolve, reject) => {
-      if( ! registrationUri) {
-        registrationUri = `https://${process.env.CLOUDFRONT_DOMAIN}`;
+      let link:string;
+      if(registrationUri) {
+        link = registrationUri;
+        const url = new URL(link);
+        if(url.pathname.startsWith('/bootstrap/')) {
+          link = `${link}?action=${Actions.register_entity}`;
+          if(entity_id) {
+            link = `${link}&entity_id=${entity_id}`
+          }    
+        }
       }
-      let link = `${registrationUri}?action=${Actions.register_entity}`;
-      if(entity_id) {
-        link = `${link}&entity_id=${entity_id}`
+      else {
+        link = `https://${process.env.CLOUDFRONT_DOMAIN}`;
       }
       resolve(link);
     });

--- a/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
+++ b/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
@@ -313,7 +313,7 @@ export const sendExhibitFormRequest = async (parms:SendExhibitFormRequestParms):
   }
 
   switch(constraint) {
-    case 'CURRENT': case 'OTHER': case 'BOTH':
+    case 'current': case 'other': case 'both':
       const sent = await new ExhibitFormRequestEmail({ 
         consenterEmail, 
         entity_id, 

--- a/lib/lambda/functions/authorized-individual/ExhibitFormRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/ExhibitFormRequestEmail.ts
@@ -10,7 +10,7 @@ export type ExhibitFormRequestEmailParms = {
   consenterEmail:string;
   entity_id:string;
   linkUri:string;
-  constraint: 'CURRENT' | 'OTHER' | 'BOTH'
+  constraint: 'current' | 'other' | 'both'
 }
 
 export class ExhibitFormRequestEmail {
@@ -52,7 +52,7 @@ export class ExhibitFormRequestEmail {
       message: `Thankyou ${consenterFullName} for registering with the Ethical Tranparency Tool.<br>` +
         `${entity_name} is requesting you take the next step and fill out a prior contacts or "exhibit" form.<br>` +
         `Follow the link provided below to log in to your ETT account and to access the form:` + 
-        `<p>${linkUri}/consenter/exhibits/${constraint}/index.htm</p>`,
+        `<p>${linkUri}/consenting/add-exhibit-form/${constraint}/index.htm</p>`,
       from: `noreply@${context.ETT_DOMAIN}`,
       attachments: []
     } as EmailParms);  
@@ -88,7 +88,7 @@ if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/functions
       consenterEmail, 
       entity_id, 
       linkUri:`https://${cloudfrontDomain}/bootstrap`, 
-      constraint:"BOTH" 
+      constraint:"both" 
     } as ExhibitFormRequestEmailParms).send();
 
     console.log('Email sent!');

--- a/lib/lambda/functions/cloudfront/ViewerRequest.ts
+++ b/lib/lambda/functions/cloudfront/ViewerRequest.ts
@@ -1,19 +1,38 @@
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+import { IContext } from "../../../../contexts/IContext";
+import * as ctx from '../../../../contexts/context.json';
+
+let bootstrapCache:string;
+let websiteCache:string;
 
 /**
  * This is a lambda@edge function for viewer request traffic to the ETT content bucket origin.
  * The purpose of this function is simply to intercept requests that match a specific uri and rewrite them to predefined value.
  * This way, more than one path can "point" to the same item in the origin bucket.
-  */
+ */
 export const handler =  async (event:any) => {
 
   try {
     const request = event.Records[0].cf.request;
     const uri = `${request.uri}`;
+    const context:IContext = <IContext>ctx;
+    const { TAGS: { Landscape }, REGION } = context;
 
     // Rewrite the request to the root index.htm if the path follows predefined patterns:
     if(uri.startsWith('/bootstrap/')) {
+      if(uri.startsWith('/bootstrap/parameters/') || uri == '/bootstrap/parameters') {
+        console.log(`Sending bootstrap parameters for incoming request uri: ${uri}`);
+        const body = await getBootstrapParm(Landscape, REGION);
+        return { status: 200, body }
+      }
       // Assume that every item being requested resides at the root of the bucket, regardless of the uri path.
       request.uri = uri.substring(uri.lastIndexOf('/'), uri.length);
+    }
+
+    if(uri.startsWith('/parameters/') || uri == '/parameters') {
+      console.log(`Sending bootstrap parameters for incoming request uri: ${uri}`);
+      const body = await getWebsiteParm(Landscape, REGION);
+      return { status: 200, body }
     }
 
     console.log(JSON.stringify({ 
@@ -24,9 +43,58 @@ export const handler =  async (event:any) => {
     return request;
   } 
   catch (e:any) {
+    console.error(e);
     return {
       status: 501,
       body: `Viewer request lambda error: ${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}`
     }
   }
+}
+
+/**
+ * Get a named parameter from the SSM parameter store.
+ * @param Name 
+ * @param region 
+ * @returns 
+ */
+const getParameter = async (Name:string, region:string): Promise<string> => {
+  try {
+    const client = new SSMClient({ region });
+    const input = { Name };
+    const command = new GetParameterCommand(input);
+    const response = await client.send(command);
+    return response.Parameter?.Value ?? '{}';
+  }
+  catch(e) {
+    console.error(e);
+    return '{}'
+  }
+}
+
+/**
+ * Get the SSM parameter store value for the bootstrap app
+ * @param landscape 
+ * @param region 
+ * @returns 
+ */
+const getBootstrapParm = async (landscape:string, region:string): Promise<string> => {
+  if(bootstrapCache) {
+    return bootstrapCache;
+  }
+  bootstrapCache = await getParameter(`/ett/${landscape}/bootstrap/static-site/parameters`, region);
+  return bootstrapCache;
+}
+
+/**
+ * Get the SSM parameter store value for the default website app
+ * @param landscape 
+ * @param region 
+ * @returns 
+ */
+const getWebsiteParm = async (landscape:string, region:string): Promise<string> => {
+  if(websiteCache) {
+    return websiteCache;
+  }
+  websiteCache = await getParameter(`/ett/${landscape}/website/static-site/parameters`, region);
+  return websiteCache;
 }

--- a/lib/lambda/functions/cloudfront/ViewerRequestParameters.ts
+++ b/lib/lambda/functions/cloudfront/ViewerRequestParameters.ts
@@ -1,0 +1,39 @@
+import { Construct } from "constructs";
+import { StaticSiteConstruct, StaticSiteConstructParms } from "../../../StaticSite";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
+import { IContext } from "../../../../contexts/IContext";
+
+export type ViewerRequestParameters = {
+  bootstrap: StaticSiteConstructParms,
+  website: StaticSiteConstructParms,
+  context: IContext
+}
+
+export class ViewerRequestParametersConstruct extends Construct {
+  constructId: string;
+  scope: Construct;
+  parms:ViewerRequestParameters;
+      
+  constructor(scope: Construct, constructId:string, parms:ViewerRequestParameters) {
+
+    super(scope, constructId);
+
+    const { context: { REDIRECT_PATH_BOOTSTRAP, REDIRECT_PATH_WEBSITE, TAGS: { Landscape } }, bootstrap, website } = parms;
+    
+    const { buildSiteParmObject } = StaticSiteConstruct;
+    const bootstrapObj = buildSiteParmObject(bootstrap, REDIRECT_PATH_BOOTSTRAP);
+    const websiteObj = buildSiteParmObject(website, REDIRECT_PATH_WEBSITE);
+
+    // Needs to be > 4KB
+    new StringParameter(this, 'BootstrapSiteParameters', {
+      parameterName: `/ett/${Landscape}/bootstrap/static-site/parameters`,
+      stringValue: JSON.stringify(bootstrapObj, null, 2),
+    });
+
+    // Needs to be > 4KB
+    new StringParameter(this, 'WebstiteParameters', {
+      parameterName: `/ett/${Landscape}/website/static-site/parameters`,
+      stringValue: JSON.stringify(websiteObj, null, 2),
+    });
+  }
+}

--- a/lib/lambda/functions/re-admin/ReAdminUser.mocks.ts
+++ b/lib/lambda/functions/re-admin/ReAdminUser.mocks.ts
@@ -638,12 +638,12 @@ export const EntityLookupTests = {
     // entity object and that entity object having been appended the two other users of the entity.
     const expectedUserInfo1 = Object.assign({}, daffyduck1) as any;
     expectedUserInfo1.entity = {
-      entity_id: 'warnerbros', entity_name: 'Warner Bros.', active: YN.Yes,
+      entity_id: 'warnerbros', entity_name: 'Warner Bros.', active: YN.Yes, totalUserCount: 3,
       users: [ Object.assign({}, porkypig), Object.assign({}, bugsbunny) ]
     };
     const expectedUserInfo2 = Object.assign({}, daffyduck2) as any;
     expectedUserInfo2.entity = {
-      entity_id: 'cartoonville', entity_name: 'Cartoon Villiage', active: YN.Yes,
+      entity_id: 'cartoonville', entity_name: 'Cartoon Villiage', active: YN.Yes, totalUserCount: 3,
       users: [ Object.assign({}, yosemitesam), Object.assign({}, foghornLeghorn) ]
     };
     delete expectedUserInfo1.entity_id;

--- a/lib/lambda/functions/sys-admin/SysAdminUser.ts
+++ b/lib/lambda/functions/sys-admin/SysAdminUser.ts
@@ -200,7 +200,7 @@ if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/functions
       const task = ReAdminTasks.INVITE_USER;
       const email = 'sysadmin1@warhen.work';
       const context:IContext = await require('../../../../contexts/context.json');
-      const { STACK_ID, REGION, TAGS: { Landscape } } = context;
+      const { STACK_ID, REGION, TAGS: { Landscape }, REDIRECT_PATH_BOOTSTRAP, REDIRECT_PATH_WEBSITE } = context;
       const prefix = `${STACK_ID}-${Landscape}`;
       
       process.env.USERPOOL_NAME = `${prefix}-cognito-userpool`; 
@@ -233,8 +233,8 @@ if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/functions
       }
 
       process.env.CLOUDFRONT_DOMAIN = cloudfrontDomain;
-      process.env.REDIRECT_URI = `${cloudfrontDomain}/bootstrap/index.htm`;
-      // process.env.REDIRECT_URI = `${cloudfrontDomain}/index.html`;
+      process.env.REDIRECT_URI = `https://${cloudfrontDomain}/${REDIRECT_PATH_BOOTSTRAP}`;
+      // process.env.REDIRECT_URI = `https://${cloudfrontDomain}/${REDIRECT_PATH_WEBSITE}`;
 
       const payload = {
         task, parameters: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@aws-sdk/client-lambda": "^3.637.0",
         "@aws-sdk/client-s3": "^3.410.0",
         "@aws-sdk/client-sesv2": "^3.509.0",
+        "@aws-sdk/client-ssm": "^3.709.0",
         "@aws-sdk/lib-dynamodb": "^3.564.0",
         "@aws-sdk/util-dynamodb": "^3.429.0",
         "@types/uuid": "^9.0.8",
@@ -4668,6 +4669,1242 @@
         }
       }
     },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.709.0.tgz",
+      "integrity": "sha512-WSm2RY7Tiix5+0V5oNqdmcKDgd10XZy8BYLPYPy0+dBHv0XcIYit5UmCHsrpgu4WBU0ppXq5XevCcMhBbJZu1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.709.0",
+        "@aws-sdk/client-sts": "3.709.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.709.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.2.0",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.709.0.tgz",
+      "integrity": "sha512-Qxeo8cN0jNy6Wnbqq4wucffAGJM6sJjofoTgNtPA6cC7sPYx7aYC6OAAAo6NaMRY+WywOKdS9Wgjx2QYRxKx7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.709.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.709.0.tgz",
+      "integrity": "sha512-1w6egz17QQy661lNCRmZZlqIANEbD6g2VFAQIJbVwSiu7brg+GUns+mT1eLLLHAMQc1sL0Ds8/ybSK2SrgGgIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.709.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.709.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sts": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.709.0.tgz",
+      "integrity": "sha512-cBAvlPg6yslXNL385UUGFPw+XY+lA9BzioNdIFkMo3fEUlTShogTtiWz4LsyLHoN6LhKojssP9DSmmWKWjCZIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.709.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.709.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/core": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.709.0.tgz",
+      "integrity": "sha512-7kuSpzdOTAE026j85wq/fN9UDZ70n0OHw81vFqMWwlEFtm5IQ/MRCLKcC4HkXxTdfy1PqFlmoXxWqeBa15tujw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/signature-v4": "^4.2.4",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.709.0.tgz",
+      "integrity": "sha512-ZMAp9LSikvHDFVa84dKpQmow6wsg956Um20cKuioPpX2GGreJFur7oduD+tRJT6FtIOHn+64YH+0MwiXLhsaIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.709.0.tgz",
+      "integrity": "sha512-lIS7XLwCOyJnLD70f+VIRr8DNV1HPQe9oN6aguYrhoczqz7vDiVZLe3lh714cJqq9rdxzFypK5DqKHmcscMEPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.709.0.tgz",
+      "integrity": "sha512-qCF8IIGcPoUp+Ib3ANhbF5gElxFd+kIrtv2/1tKdvhudMANstQbMiWV0LTH47ZZR6c3as4iSrm09NZnpEoD/pA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.709.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.709.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.709.0.tgz",
+      "integrity": "sha512-4HRX9KYWPSjO5O/Vg03YAsebKpvTjTvpK1n7zHYBmlLMBLxUrVsL1nNKKC5p2/7OW3RL8XR1ki3QkoV7kGRxUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-ini": "3.709.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.709.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.709.0.tgz",
+      "integrity": "sha512-IAC+jPlGQII6jhIylHOwh3RgSobqlgL59nw2qYTURr8hMCI0Z1p5y2ee646HTVt4WeCYyzUAXfxr6YI/Vitv+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.709.0.tgz",
+      "integrity": "sha512-rYdTDOxazS2GdGScelsRK5CAkktRLCCdRjlwXaxrcW57j749hEqxcF5uTv9RD6WBwInfedcSywErNZB+hylQlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.709.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/token-providers": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.709.0.tgz",
+      "integrity": "sha512-2lbDfE0IQ6gma/7BB2JpkjW5G0wGe4AS0x80oybYAYYviJmUtIR3Cn2pXun6bnAWElt4wYKl4su7oC36rs5rNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.709.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.709.0.tgz",
+      "integrity": "sha512-8gQYCYAaIw4lOCd5WYdf15Y/61MgRsAnrb2eiTl+icMlUOOzl8aOl5iDwm/Idp0oHZTflwxM4XSvGXO83PRWcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.709.0.tgz",
+      "integrity": "sha512-jDoGSccXv9zebnpUoisjWd5u5ZPIalrmm6TjvPzZ8UqzQt3Beiz0tnQwmxQD6KRc7ADweWP5Ntiqzbw9xpVajg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.709.0.tgz",
+      "integrity": "sha512-PObL/wLr4lkfbQ0yXUWaoCWu/jcwfwZzCjsUiXW/H6hW9b/00enZxmx7OhtJYaR6xmh/Lcx5wbhIoDCbzdv0tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.709.0.tgz",
+      "integrity": "sha512-ooc9ZJvgkjPhi9q05XwSfNTXkEBEIfL4hleo5rQBKwHG3aTHvwOM7LLzhdX56QZVa6sorPBp6fwULuRDSqiQHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.709.0.tgz",
+      "integrity": "sha512-/NoCAMEVKAg3kBKOrNtgOfL+ECt6nrl+L7q2SyYmrcY4tVCmwuECVqewQaHc03fTnJijfKLccw0Fj+6wOCnB6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/token-providers": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.709.0.tgz",
+      "integrity": "sha512-q5Ar6k71nci43IbULFgC8a89d/3EHpmd7HvBzqVGRcHnoPwh8eZDBfbBXKH83NGwcS1qPSRYiDbVfeWPm4/1jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.709.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/types": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.709.0.tgz",
+      "integrity": "sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.709.0.tgz",
+      "integrity": "sha512-Mbc7AtL5WGCTKC16IGeUTz+sjpC3ptBda2t0CcK0kMVw3THDdcSq6ZlNKO747cNqdbwUvW34oHteUiHv4/z88Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-endpoints": "^2.1.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.709.0.tgz",
+      "integrity": "sha512-/rL2GasJzdTWUURCQKFldw2wqBtY4k4kCiA2tVZSKg3y4Ey7zO34SW8ebaeCE2/xoWOyLR2/etdKyphoo4Zrtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.709.0.tgz",
+      "integrity": "sha512-trBfzSCVWy7ILgqhEXgiuM7hfRCw4F4a8IK90tjk9YL0jgoJ6eJuOp7+DfCtHJaygoBxD3cdMFkOu+lluFmGBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/abort-controller": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/config-resolver": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
+      "integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/core": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.5.tgz",
+      "integrity": "sha512-G8G/sDDhXA7o0bOvkc7bgai6POuSld/+XhNnWAbpQTpLv2OZPvyqQ58tLPPlz0bSNsXktldDDREIv1LczFeNEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
+      "integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.2.tgz",
+      "integrity": "sha512-R7rU7Ae3ItU4rC0c5mB2sP5mJNbCfoDc8I5XlYjIZnquyUwec7fEo78F6DA3SmgJgkU1qTMcZJuGblxZsl10ZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/hash-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
+      "integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
+      "integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
+      "integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.5.tgz",
+      "integrity": "sha512-VhJNs/s/lyx4weiZdXSloBgoLoS8osV0dKIain8nGmx7of3QFKu5BSdEuk1z/U8x9iwes1i+XCiNusEvuK1ijg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.30.tgz",
+      "integrity": "sha512-6323RL2BvAR3VQpTjHpa52kH/iSHyxd/G9ohb2MkBk2Ucu+oMtRXT8yi7KTSIS9nb58aupG6nO0OlXnQOAcvmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+      "integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+      "integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+      "integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/node-http-handler": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.2.tgz",
+      "integrity": "sha512-t4ng1DAd527vlxvOfKFYEe6/QFBcsj7WpNlWTyjorwXXcKw3XlltBGbyHfSJ24QT84nF+agDha9tNYpzmSRZPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/property-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/protocol-http": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+      "integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/signature-v4": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.4.tgz",
+      "integrity": "sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/smithy-client": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.5.0.tgz",
+      "integrity": "sha512-Y8FeOa7gbDfCWf7njrkoRATPa5eNLUEjlJS5z5rXatYuGkCb80LbHcu8AQR8qgAZZaNHCLyo2N+pxPsV7l+ivg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/url-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+      "integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.30.tgz",
+      "integrity": "sha512-nLuGmgfcr0gzm64pqF2UT4SGWVG8UGviAdayDlVzJPNa6Z4lqvpDzdRXmLxtOdEjVlTOEdpZ9dd3ZMMu488mzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.30.tgz",
+      "integrity": "sha512-OD63eWoH68vp75mYcfYyuVH+p7Li/mY4sYOROnauDrtObo1cS4uWfsy/zhOTW8F8ZPxQC1ZXZKVxoxvMGUv2Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-endpoints": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
+      "integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-stream": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.2.tgz",
+      "integrity": "sha512-sInAqdiVeisUGYAv/FrXpmJ0b4WTFmciTRqzhb7wVuem9BHvhIG7tpiYHLDWrl2stOokNZpTTGqz3mzB2qFwXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-waiter": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.2.0.tgz",
+      "integrity": "sha512-PpjSboaDUE6yl+1qlg3Si57++e84oXdWGbuFUSAciXsVfEZJJJupR2Nb0QuXHiunt2vGR+1PTizOMvnUPaG2Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.507.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.507.0.tgz",
@@ -7864,8 +9101,7 @@
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "redeploy": "npm run teardown && npm run deploy",
     "preteardown": "ts-node bin/PreTeardown.ts",
     "teardown": "npm run preteardown && cdk destroy --all -f",
-    "synth": "cdk synth 2>&1 | tee cdk.out/ett.template.yaml",
+    "synth": "cdk synth --all 2>&1 | tee cdk.out/ett.template.yaml",
     "clearcache": "sh bin/clearcache.sh",
     "publish": "sh bin/publish.sh"
   },
@@ -41,6 +41,7 @@
     "@aws-sdk/client-lambda": "^3.637.0",
     "@aws-sdk/client-s3": "^3.410.0",
     "@aws-sdk/client-sesv2": "^3.509.0",
+    "@aws-sdk/client-ssm": "^3.709.0",
     "@aws-sdk/lib-dynamodb": "^3.564.0",
     "@aws-sdk/util-dynamodb": "^3.429.0",
     "@types/uuid": "^9.0.8",


### PR DESCRIPTION
This feature implements a public endpoint that returns all the urls (cloudfront, cognito, api-gateway, etc) necessary for single-page app clients to communicate with the ETT backend.

- This information has been injected directly into the bootstrap single-page app html file, but is now also available at: "/bootstrap/parameters"
- For non-bootstrap apps, the information is available at a "/parameters" endpoint.

NOTE: This has not been implemented through an api-gateway endpoint, but has instead been provided through a cloudfront@edge viewer request lambda function that screens for the parameters endpoint and immediately returns a response with the parameter information, sending all other requests through to the origin.