### PR TITLE
Routing2

### DIFF
--- a/contexts/IContext.ts
+++ b/contexts/IContext.ts
@@ -5,11 +5,13 @@ export interface IContext {
   STACK_ID: string;
   ACCOUNT:  string;
   REGION:   string;
+  LOCALHOST?: string;
   ETT_DOMAIN?: string;
   CLOUDFRONT_DOMAIN?: string;
   CLOUDFRONT_CERTIFICATE?: string;
   REDIRECT_PATH_WEBSITE:string;
   REDIRECT_PATH_BOOTSTRAP:string;
+  DEFAULT_ROOT_OBJECT:string;
   CONFIG: CONFIG;
   TAGS:     Tags;
 }

--- a/contexts/context.json
+++ b/contexts/context.json
@@ -3,9 +3,11 @@
   "STACK_ID": "ett",
   "ACCOUNT": "037860335094",
   "REGION": "us-east-2",
+  "LOCALHOST": "http://localhost:5173",
   "ETT_DOMAIN": "warhen.work",
   "REDIRECT_PATH_BOOTSTRAP": "bootstrap/index.htm",
   "REDIRECT_PATH_WEBSITE": "/",
+  "DEFAULT_ROOT_OBJECT": "index.html",
   "CONFIG": {
     "useDatabase": true,
     "configs": [

--- a/contexts/context.json
+++ b/contexts/context.json
@@ -5,7 +5,7 @@
   "REGION": "us-east-2",
   "ETT_DOMAIN": "warhen.work",
   "REDIRECT_PATH_BOOTSTRAP": "bootstrap/index.htm",
-  "REDIRECT_PATH_WEBSITE": "index.html",
+  "REDIRECT_PATH_WEBSITE": "/",
   "CONFIG": {
     "useDatabase": true,
     "configs": [

--- a/lib/Cloudfront.ts
+++ b/lib/Cloudfront.ts
@@ -34,7 +34,10 @@ export class CloudfrontConstruct extends Construct {
     this.context = scope.node.getContext('stack-parms');
     this.scope = scope;
     this.props = props;
-    const { context: { TAGS: { Landscape:landscape }, STACK_ID, REDIRECT_PATH_WEBSITE } } = this;
+    const { 
+      context: { TAGS: { Landscape:landscape }, STACK_ID, 
+      REDIRECT_PATH_WEBSITE, DEFAULT_ROOT_OBJECT
+    } } = this;
     const  defaultBehavior = { 
       origin: new HttpOrigin('dummy-origin.com', { originId: 'dummy-origin' })
     }
@@ -42,7 +45,7 @@ export class CloudfrontConstruct extends Construct {
     this.distribution = new Distribution(this, 'Distribution', {
       defaultBehavior,
       comment: `${STACK_ID}-${landscape}-distribution`,
-      defaultRootObject: REDIRECT_PATH_WEBSITE,
+      defaultRootObject: DEFAULT_ROOT_OBJECT,
       logBucket: new Bucket(this, 'DistributionLogsBucket', {
         removalPolicy: RemovalPolicy.DESTROY,    
         autoDeleteObjects: true,
@@ -62,7 +65,7 @@ export class CloudfrontConstruct extends Construct {
     cfnDist.addPropertyOverride('DistributionConfig.CustomErrorResponses', [ {
       ErrorCode: 403,
       ResponseCode: 200,
-      ResponsePagePath: `/${REDIRECT_PATH_WEBSITE}`,
+      ResponsePagePath: `/${DEFAULT_ROOT_OBJECT}`,
     }]);
   }
 

--- a/lib/StaticSite.ts
+++ b/lib/StaticSite.ts
@@ -51,6 +51,9 @@ export abstract class StaticSiteConstruct extends Construct {
    * @returns A parameter object comprising all values client apps need to authenticate and talk with the backend.
    */
   public static buildSiteParmObject = (parms: StaticSiteConstructParms, redirectPath:string):any => {
+    if(redirectPath.startsWith('/')) {
+      redirectPath = redirectPath.substring(1);
+    }
     let jsonObj = {
       COGNITO_DOMAIN: parms.cognitoDomain,
       USER_POOL_REGION: parms.cognitoUserpoolRegion,

--- a/lib/StaticSiteWebsite.ts
+++ b/lib/StaticSiteWebsite.ts
@@ -8,7 +8,7 @@ import { StaticSiteConstruct, StaticSiteConstructParms } from "./StaticSite";
 /**
  * This construct is for an s3 bucket that is to host the single page app html file and related
  * artifacts. This bucket will be empty when the stack is deployed, and it is intended that an 
- * independent author will drop their app into this bucket, with the main file being named index.html.
+ * independent author will drop their app into this bucket.
  */
 export class StaticSiteWebsiteConstruct extends StaticSiteConstruct {
 

--- a/lib/lambda/_lib/cognito/CallbackUrls.ts
+++ b/lib/lambda/_lib/cognito/CallbackUrls.ts
@@ -1,0 +1,201 @@
+import { IContext } from "../../../../contexts/IContext";
+import { Actions } from "../../../role/AbstractRole";
+import { Role, Roles } from "../dao/entity";
+
+/**
+ * Factory for callback urls expected by cognito app clients
+ * SEE: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-client-apps.html#cognito-user-pools-app-idp-settings-about
+ * NOTE: If the pathname appears to end with a file (has file extension), it assumed that the callback url 
+ * is for the bootstrap app (or something like it) and will have applied to it extra query string parameters.
+ * Else it is for something like a react app using routes, with more focus on parameters being path elements.
+ */
+export class CallbackUrlFactory {
+  private rootUrl:URL
+  private role:Role;
+
+  constructor(host:string, pathname:string, role:Role) {
+    this.role = role;
+    this.rootUrl = new URL(host.startsWith('http') ? host : `https://${host}`);
+    if(pathname && pathname != '/') {
+      this.rootUrl.pathname = pathname;
+    }
+  }
+
+  private clone = (url:URL=this.rootUrl) => new URL(url.href);
+
+  private extendedPathUrl = (segments:string):URL => this.pathNameUtils(this.clone()).appendMoreSegments(segments);
+
+  /**
+   * Decorator for URL.pathname for extra functionality
+   * @param url 
+   * @returns 
+   */
+  private pathNameUtils = (url:URL) => {
+    const { clone } = this;
+    const { pathname } = url;
+    let parts = pathname.split('/').filter(segment => segment);
+    let file:string;
+    if(parts.length > 0) {
+      const tail = parts[parts.length-1];
+      if(tail.includes('.')) {
+        file = parts.pop() ?? '';
+      }
+    }
+    return {
+      endsWithFile: () => (file ?? '').length > 0,
+      appendMoreSegments: (path:string|undefined):URL => {
+        if( ! path) return url;
+        const allParts = [] as string[];
+        allParts.push(...parts);
+        const newParts = path.split('/').filter(segment => segment);
+        allParts.push(...newParts);
+        const newUrl = clone(url);
+        if(file) {
+          allParts.push(file);
+        }
+        newUrl.pathname = allParts.join('/');
+        return newUrl;
+      }
+    }
+  }
+
+  /**
+   * @returns The callback urls expected by a cognito app client
+   */
+  public getCallbackUrls = ():string[] => {
+    const { role, clone, pathNameUtils, extendedPathUrl } = this;
+    const urls = [] as string[];
+    const path = pathNameUtils(clone());
+    let url:URL;
+
+    url = clone();
+    urls.push(url.href);
+    if(url.pathname.endsWith('/')) {
+      urls.push(url.href.substring(0, url.href.length-1))
+    }
+
+    if(path.endsWithFile()) {
+      url = clone();
+      url.searchParams.set('action', Actions.login);
+      url.searchParams.set('selected_role', role);
+      urls.push(url.href);
+      if(role != Roles.CONSENTING_PERSON) {
+        url.searchParams.set('task', 'amend');
+        urls.push(url.href);
+      }
+      
+      url = clone();
+      url.searchParams.set('action', Actions.post_signup);
+      url.searchParams.set('selected_role', role);
+      urls.push(url.href);      
+      if(role != Roles.CONSENTING_PERSON) {
+        url.searchParams.set('task', 'amend');
+        urls.push(url.href);
+      }
+    }
+    else {
+      url = extendedPathUrl('/amend-entity');
+      urls.push(url.href);
+    }
+
+    if(role == Roles.CONSENTING_PERSON) {
+      const addEntityInviteCallback = (exhibitType:'current'|'other'|'both') => {
+        url = extendedPathUrl(`/consenting/add-exhibit-form/${exhibitType}`);
+        if(path.endsWithFile()) {
+          url.searchParams.set('action', Actions.login);
+          url.searchParams.set('selected_role', role);
+        }
+        urls.push(url.href);
+      }
+      addEntityInviteCallback('both');
+      addEntityInviteCallback('current');
+      addEntityInviteCallback('other');
+    }
+
+    return urls;
+  }
+
+  /**
+   * @returns The logout urls expected by a cognito app client
+   */
+  public getLogoutUrls = ():string[] => {
+    const { role, clone, pathNameUtils, extendedPathUrl } = this;
+    const urls = [] as string[];
+    const path = pathNameUtils(clone());
+    let url:URL;
+
+    url = clone();
+    if(path.endsWithFile()) {
+      url.searchParams.set('action', Actions.logout);
+      urls.push(url.href);
+    }
+    else {
+      urls.push(url.href);
+      if(url.pathname.endsWith('/')) {
+        urls.push(url.href.substring(0, url.href.length-1));
+      }
+      urls.push(extendedPathUrl('/logout').href);
+    }
+    
+    if(role == Roles.CONSENTING_PERSON && path.endsWithFile()) {
+      const addEntityInviteCallback = (exhibitType:'current'|'other'|'both') => {
+        url = extendedPathUrl(`/consenting/add-exhibit-form/${exhibitType}`);
+        url.searchParams.set('action', Actions.logout);
+        urls.push(url.href);
+      }
+      addEntityInviteCallback('both');
+      addEntityInviteCallback('current');
+      addEntityInviteCallback('other');
+    }
+
+    return urls;
+  }
+}
+
+ 
+
+
+
+/**
+ * RUN MANUALLY
+ */
+const { argv:args } = process;
+if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/_lib/cognito/CallbackUrls.ts')) {
+  (async () => {
+    // Cannot import utils at the top of the page because it introduces the following circular reference issue:
+    // ../lib/lambda/Utils.ts > ../lib/role/AbstractRole.ts > ../lib/CognitoUserPoolClient.ts > ../lib/lambda/_lib/cognito/CallbackUrls.ts
+    const utils = await require('../../Utils');
+    
+    const context:IContext = await require('../../../../contexts/context.json');
+    const { REDIRECT_PATH_BOOTSTRAP, REDIRECT_PATH_WEBSITE, TAGS: { Landscape } } = context;
+    const { SYS_ADMIN, RE_ADMIN, RE_AUTH_IND, CONSENTING_PERSON } = Roles;
+
+    // Get the cloudfront domain
+    let host:string;
+    try {
+      host = await utils.lookupCloudfrontDomain(Landscape) ?? 'error';
+    }
+    catch(e:any) {
+      if(e.name == 'ExpiredToken') {
+        console.log('Expired token! Using dummy value for domain');
+        host = 'mycloudfrontDomain.net';
+      }
+      else {
+        throw(e);
+      }
+    }
+    
+    // Print out all the callback and logout urls for each cognito app client (one client per role)
+    [ SYS_ADMIN, RE_ADMIN, RE_AUTH_IND, CONSENTING_PERSON ].forEach((role:Role) => {
+      const callbackUrls = [] as string[];
+      const logoutUrls = [] as string[];
+      let factory = new CallbackUrlFactory(host, REDIRECT_PATH_BOOTSTRAP, role);
+      callbackUrls.push(...factory.getCallbackUrls());
+      logoutUrls.push(...factory.getLogoutUrls());
+      factory = new CallbackUrlFactory(host, REDIRECT_PATH_WEBSITE, role);
+      callbackUrls.push(...factory.getCallbackUrls());
+      logoutUrls.push(...factory.getLogoutUrls());
+      utils.log({ role, callbackUrls, logoutUrls });
+    });
+  })();
+}

--- a/lib/lambda/_lib/cognito/CallbackUrls.ts
+++ b/lib/lambda/_lib/cognito/CallbackUrls.ts
@@ -63,7 +63,8 @@ export class CallbackUrlFactory {
    * @returns The callback urls expected by a cognito app client
    */
   public getCallbackUrls = ():string[] => {
-    const { role, clone, pathNameUtils, extendedPathUrl } = this;
+    const { TEMP_HOST } = CallbackUrlFactory;
+    const { role, clone, pathNameUtils, extendedPathUrl, token } = this;
     const urls = [] as string[];
     const path = pathNameUtils(clone());
     let url:URL;
@@ -112,14 +113,15 @@ export class CallbackUrlFactory {
       addEntityInviteCallback('other');
     }
 
-    return urls;
+    return token ? urls.map(url => url.replace(TEMP_HOST, token)) : urls;
   }
 
   /**
    * @returns The logout urls expected by a cognito app client
    */
   public getLogoutUrls = ():string[] => {
-    const { role, clone, pathNameUtils, extendedPathUrl } = this;
+    const { TEMP_HOST } = CallbackUrlFactory;
+    const { role, clone, pathNameUtils, extendedPathUrl, token } = this;
     const urls = [] as string[];
     const path = pathNameUtils(clone());
     let url:URL;
@@ -148,7 +150,7 @@ export class CallbackUrlFactory {
       addEntityInviteCallback('other');
     }
 
-    return urls;
+    return token ? urls.map(url => url.replace(TEMP_HOST, token)) : urls;
   }
 }
 

--- a/lib/lambda/_lib/invitation/Invitation.ts
+++ b/lib/lambda/_lib/invitation/Invitation.ts
@@ -211,8 +211,8 @@ export class UserInvitation {
 const { argv:args } = process;
 if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/_lib/invitation/Invitation.ts')) {
 
-  const inviterEmail = 'asp.au.edu@warhen.work';
-  const inviteeEmail = 'auth1.au.edu@warhen.work';
+  const inviterEmail = 'asp1.random.edu@warhen.work';
+  const inviteeEmail = 'auth1.random.edu@warhen.work';
   const role = Roles.RE_AUTH_IND;
 
   (async () => {
@@ -243,7 +243,8 @@ if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/_lib/invi
 
     // Get the link to put in the invitation email
     const entity_id = inviters[0].entity_id;
-    const registrationUri = 'https"//' + cloudfrontDomain + '/bootstrap/index.htm';
+    // const registrationUri = 'https://' + cloudfrontDomain + '/bootstrap/index.htm';
+    const registrationUri = 'https://' + cloudfrontDomain + '/entity/register';
     const link = await new SignupLink().getRegistrationLink({ entity_id, registrationUri });
     
     // Get the entity

--- a/lib/lambda/_lib/invitation/SignupLink.test.ts
+++ b/lib/lambda/_lib/invitation/SignupLink.test.ts
@@ -94,7 +94,7 @@ describe('Registration signup link', () => {
     expect(link).toEqual(expectedLink);
 
     const registrationUri = 'https://mydomain/path/to/something';
-    expectedLink = registrationUri;
+    expectedLink = `${registrationUri}?entity_id=${entity_id}`;
     link = await signupLink.getRegistrationLink({ entity_id, registrationUri });
     expect(link).toEqual(expectedLink);
   })

--- a/lib/lambda/_lib/invitation/SignupLink.ts
+++ b/lib/lambda/_lib/invitation/SignupLink.ts
@@ -100,7 +100,10 @@ export class SignupLink {
           link = `${link}?action=${Actions.register_entity}`;
           if(entity_id) {
             link = `${link}&entity_id=${entity_id}`
-          }    
+          } 
+        }
+        else if(entity_id) {
+          link = `${link}?entity_id=${entity_id}`
         }
       }
       else {


### PR DESCRIPTION
This feature accommodates more of the routing needs for a frontend being developed separately in react.
This includes:

- Making the default root address for the app be the cloudfront domain itself.
- Refactoring and the cognito app client callback/logout url generation to a separate class and adding more urls.
- Including localhost as a cognito app client callback/logout url option _(non-prod environments only)_
- Bug fixes.