### PR TITLE
Entity shortcuts

### DIFF
--- a/bin/teardown.sh
+++ b/bin/teardown.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+###############################################################################################
+# After running pre-teardown.ts, all replicated lambda@edge functions have been deleted.
+# However, it seems cloudformation does not "catch up" with that fact until some time 
+# after this state has been reached. This script, therefore, will repeate attempts to delete 
+# the stack until cloudformation stops complaining about the existence of replicated functions
+# preventing the deletion of the "parent" lambda@edge function. This may take a few minutes.
+###############################################################################################
+
+# Have stack destroy attempts be repeated for half an hour before giving up
+iteration_inverval=10 # Seconds
+max_iterations=180
+
+# Loop until the command succeeds or reaches 100 iterations
+for ((i = 1; i <= $max_iterations; i++)); do
+  echo "Attempt $i..."
+
+  # Create temporary files for stdout and stderr
+  temp_stdout=$(mktemp)
+  temp_stderr=$(mktemp)
+
+  # TEST: error without "replicated"
+  # { { (>&2 echo "An error has been thrown"; false) 1> >(tee "$temp_stdout"); } 2> "$temp_stderr"; }
+
+  # TEST: error WITH "replicated"
+  # { { (>&2 echo "An error has been replicated"; false) 1> >(tee "$temp_stdout"); } 2> "$temp_stderr"; }
+
+  # TEST: non-error command
+  # { { (ls -la) 1> >(tee "$temp_stdout"); } 2> "$temp_stderr"; }
+
+  # Run the command
+  { { (cdk destroy --all -f) 1> >(tee "$temp_stdout"); } 2> "$temp_stderr"; } 
+
+  # Check the exit status of the command
+  exit_code=$?
+
+  # Capture the output into variables
+  stdout_var=$(<"$temp_stdout")
+  stderr_var=$(<"$temp_stderr")
+
+  # Clean up temporary files
+  rm "$temp_stdout" "$temp_stderr"
+  
+  # Check if the command succeeded
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Stack successfully deleted."
+    break
+  fi
+  
+  # Check if it's the anticipated "replicated" error
+  if echo "$stderr_var" | grep -iq "replicated"; then
+    echo 'It appears cloudfront is still not "aware" that all replicated functions have been deleted.'
+  else
+    echo "Unexpected error:"$'\n'"$stderr_var"
+    exit 1
+  fi
+
+  # Check if the maximum iteration count has been reached
+  if [[ $i -ge $max_iterations ]]; then
+    echo "Reached maximum iterations ($max_iterations). Exiting..."
+    exit 1
+  fi
+  
+  # Add a delay between retries
+  echo "Trying again in ${iteration_inverval} seconds"
+  sleep $iteration_inverval
+done
+

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -956,15 +956,15 @@
 
                       <table class="sysAdminShortcuts">
                         <tr class="open">
-                          <th colspan="2">Setup a new Entity</th>
+                          <th colspan="3">Setup a new Entity</th>
                         </tr>
                         <tr>
                           <td>Entity Name</td>
-                          <td><input id="txtShortcutEntityName" type="text" class="form-control" value="The School of Hard Knocks"></td>
+                          <td colspan="2"><input id="txtShortcutEntityName" type="text" class="form-control" value="The School of Hard Knocks"></td>
                         </tr>
                         <tr>
                           <td>Representatives</td>
-                          <td>
+                          <td colspan="3">
                             <table class="sysAdminShortcuts">
                               <tr>
                                 <td>Role</td>
@@ -998,34 +998,30 @@
                           </td>
                         </tr>
                         <tr>
-                          <td style="align-items: end;" colspan="2">
-                            <button id="btnShortcutsCreateEntity" class="btn btn-primary">CREATE & STAFF ENTITY</button> 
+                          <td style="align-items: end;" colspan="3">
+                            <button id="btnShortcutsCreateEntity" class="btn btn-success" style="width:200px;">CREATE & STAFF ENTITY</button> 
                           </td>
                         </tr>
                         <tr>
-                          <td colspan="2" style="border-style:none;">&nbsp;</td>
+                          <td colspan="3" style="border-style:none;">&nbsp;</td>
                         </tr>
                         <tr class="open">
-                          <th colspan="2">Tear down an entity</th>
+                          <th colspan="3">Tear down an entity</th>
                         </tr>
                         <tr>
-                          <tr>
-                            <td>Entity</td>
-                            <td>
-                              <div id="sysAdminEntityDropdown" class="dropdown">
-                                <b>Select One:</b>&nbsp;                          
-                                <button id="sysAdminEntityDropdownButton" class="btn btn-primary btn-lg dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                  Organizations/Entities
-                                </button>
-                                <div id="sysAdminEntityDropdownList" class="dropdown-menu" aria-labelledby="sysAdminEntityDropdownButton">
-                                </div>                          
-                              </div>
-                            </td>
-                          </tr>
-                        </tr>
-                        <tr>
-                          <td style="align-items: end;" colspan="2">
-                            <button id="btnShortcutsRemoveEntity" class="btn btn-primary">TEAR DOWN ENTITY</button> 
+                          <td>Entity</td>
+                          <td>
+                            <div id="sysAdminEntityDropdown" class="dropdown">
+                              <b>Select One:</b>&nbsp;                          
+                              <button id="sysAdminEntityDropdownButton" class="btn btn-primary btn-lg dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                Organizations/Entities
+                              </button>
+                              <div id="sysAdminEntityDropdownList" class="dropdown-menu" aria-labelledby="sysAdminEntityDropdownButton">
+                              </div>                          
+                            </div>
+                          </td>
+                          <td style="align-items: end; text-align:right;">
+                            <button id="btnShortcutsRemoveEntity" class="btn btn-danger" style="width:200px;">TEAR DOWN ENTITY</button> 
                           </td>
                         </tr>
                       </table>
@@ -2433,6 +2429,95 @@
           a.innerText = entity_name;
           lbx.appendChild(a);
         });
+      }
+    }
+
+    const sendSysAdminEntitySetupRequest = async () => {
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      try {
+
+        const outgoingPayload = { task: 'shortcut-entity-setup', parameters: { 
+          entityName: document.getElementById('txtShortcutEntityName').value, 
+          asp: {
+            email: document.getElementById('txtShortcutAspEmail').value,
+            fullname: document.getElementById('txtShortcutAspFullname').value,
+            phone_number: document.getElementById('txtShortcutAspPhone').value,
+            title: document.getElementById('txtShortcutAspTitle').value
+          }, 
+          ais: [
+            {
+              email: document.getElementById('txtShortcutAuth1Email').value,
+              fullname: document.getElementById('txtShortcutAuth1Fullname').value,
+              phone_number: document.getElementById('txtShortcutAuth1Phone').value,
+              title: document.getElementById('txtShortcutAuth1Title').value
+            },
+            {
+              email: document.getElementById('txtShortcutAuth2Email').value,
+              fullname: document.getElementById('txtShortcutAuth2Fullname').value,
+              phone_number: document.getElementById('txtShortcutAuth2Phone').value,
+              title: document.getElementById('txtShortcutAuth2Title').value
+            }
+          ] 
+        }};
+
+        const response = await fetch(apiUri('SYS_ADMIN'), {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify(outgoingPayload)
+          }
+        });
+
+        const package = await response.json();
+        const { message, payload: { ok } } = package;
+        if(ok) {
+          alert('Entity setup successful');
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
+    }
+
+    const sendSysAdminEntityTeardownRequest = async () => {
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      if( ! selectedEntity) {
+        alert('Entity selection required');
+        return;
+      }
+      const parameters = selectedEntity;
+      try {
+        const outgoingPayload = { task: 'shortcut-entity-teardown', parameters };
+        const response = await fetch(apiUri('SYS_ADMIN'), {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify(outgoingPayload)
+          }
+        });
+
+        const package = await response.json();
+        const { message, payload: { ok } } = package;
+        if(ok) {
+          alert('Entity teardown successful');
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
       }
     }
 
@@ -4803,6 +4888,24 @@
           }
           toggleExhibitCorrectionByEntity(_event)
         });
+      });
+
+      // Add behavior to selection activity on the entity picklist for sysadmin shortcuts tab
+      $('#sysAdminEntityDropdownButton').on('hide.bs.dropdown', function () {
+        const { srcElement:a } = event;
+        if(a.tagName == 'A' && a.name && a.id) {
+          const button = document.getElementById('sysAdminEntityDropdownButton');
+          button.innerText = a.name;
+          selectedEntity = { entity_id: a.id };
+        }
+      });
+
+      $('#btnShortcutsCreateEntity').on('click', async () => {
+        await sendSysAdminEntitySetupRequest();
+      });      
+
+      $('#btnShortcutsRemoveEntity').on('click', async () => {
+        await sendSysAdminEntityTeardownRequest();
       });
 
       // Add behavior to selection activity on the consenter picklist for exhibit form requests

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -1012,9 +1012,14 @@
                           <tr>
                             <td>Entity</td>
                             <td>
-                              <select id="lbxSysAdminEntities2" class="form-control">
-                                <option><-- Select One --></option>
-                              </select>
+                              <div id="sysAdminEntityDropdown" class="dropdown">
+                                <b>Select One:</b>&nbsp;                          
+                                <button id="sysAdminEntityDropdownButton" class="btn btn-primary btn-lg dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                  Organizations/Entities
+                                </button>
+                                <div id="sysAdminEntityDropdownList" class="dropdown-menu" aria-labelledby="sysAdminEntityDropdownButton">
+                                </div>                          
+                              </div>
                             </td>
                           </tr>
                         </tr>
@@ -2372,6 +2377,65 @@
       }
     }
 
+    /**
+     * Call the sysadmin api endpoint for a listing of entities (both active and inactive)
+     */
+    const fetchSysAdminEntityList = async () => {
+      const msg = document.getElementById('apiResponse');
+      msg.innerHTML = '';
+      const entityList = [];
+      try {
+        const outgoingPayload = { task: 'get-entity-list', parameters: {} };
+        const response = await fetch(apiUri('SYS_ADMIN'), {
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+            'Content-Type': 'application/json',
+            [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify(outgoingPayload)
+          }
+        });
+
+        const package = await response.json();
+        const { message, payload: { ok, entities=[] } } = package;
+        if(ok) {
+          // Populate the picklist with the fetched entity data
+          entityList.push(...entities);
+        }
+        else {
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
+        }
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
+      finally {
+        return entityList;
+      }
+    }
+
+    /**
+     * Populate the entity picklist of the sysadmin shortcuts tab from fetched entity data
+     */
+    const populateSysAdminEntityList = async () => {
+      const lbx = document.querySelector(`#sysAdminEntityDropdownList`);
+      lbx.innerHTML = '';
+      const entities = await fetchSysAdminEntityList();
+      if(entities.length > 0) {
+        entities.forEach(entity => {
+          const { entity_id, entity_name } = entity;
+          const a = document.createElement("a");
+          a.id = entity_id;
+          a.name = entity_name;
+          a.className = 'dropdown-item';
+          a.href = '#';
+          a.innerText = entity_name;
+          lbx.appendChild(a);
+        });
+      }
+    }
+
     const sendDisclosureRequest = async () => {
       const msg = document.getElementById('apiResponse');
       msg.innerHtml = '';
@@ -2691,12 +2755,12 @@
       }
     }
 
-    const populateEntityLists = () => {
-      populateEntityList('requestingEntityDropdownList');
-      populateEntityList('requestingEntityDropdownList2');
+    const populateConsenterEntityLists = () => {
+      populateConsenterEntityList('requestingEntityDropdownList');
+      populateConsenterEntityList('requestingEntityDropdownList2');
     }
 
-    const populateEntityList = (listId) => {
+    const populateConsenterEntityList = (listId) => {
       const { consenter: { exhibit_forms=[] }, entities } = consenterInfo;
       if( entities.length == 0) {
         return;
@@ -2720,7 +2784,7 @@
           a.innerHTML = `${entity_name} <span style="font-style:italic">(Saved)</span>`;
         }
         else {
-          // No exhbit form has yet been saved for this entity
+          // No exhibit form has yet been saved for this entity
           a.innerText = entity_name;
         }
         lbx.appendChild(a);
@@ -2752,7 +2816,7 @@
       document.getElementById('consenter-correct-fullname').innerHTML = fullName;
       document.getElementById('consenter-correct-email').innerHTML = email;
       document.getElementById('consenter-correct-phone').innerHTML = phone_number;
-      populateEntityLists();
+      populateConsenterEntityLists();
       return consenterInfo;
     }
 
@@ -3325,7 +3389,7 @@
       const payload = getExhibitFormPayload();
       await sendExhibitFormPayload('save-exhibit-form', payload, () => {
         alert('Exhibit form saved.');
-        populateEntityLists();
+        populateConsenterEntityLists();
       });
     }
 
@@ -3337,7 +3401,7 @@
       const payload = getExhibitFormPayload();
       await sendExhibitFormPayload('send-exhibit-form', payload, () => {
         alert('Exhibit form submitted.');
-        populateEntityLists();
+        populateConsenterEntityLists();
       });
     }
 
@@ -4814,6 +4878,7 @@
             case 'SYS_ADMIN':
               document.getElementById('app-section-SYS_ADMIN').style.display = 'inline';
               document.getElementsByName('rdoSysAdminInvite')[1].click();
+              await populateSysAdminEntityList();
               break;
 
             case 'RE_ADMIN':

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -218,6 +218,16 @@
         padding: 10px;
       }
 
+      .divSysAdminOption2 {
+        float:left; 
+        clear:both; 
+        text-align:left; 
+        font-weight:bold; 
+        font-size:16px;
+        vertical-align: middle;
+        padding: 10px;
+      }
+
       h3 {
         text-align: center;
         margin-bottom: 20px;
@@ -338,6 +348,32 @@
       div.bdp-block input, div.bdp-block div {
         width:70px;
         display:inline-table;      
+      }
+
+      table.sysAdminShortcuts th, table.sysAdminShortcuts td {
+        border: 1px solid #cccccc;
+        border-collapse: collapse;
+      }
+      table.sysAdminShortcuts tr.open th, table.sysAdminShortcuts tr.open td {
+        border-style:none;
+      }
+      table.sysAdminShortcuts td:nth-child(1) {
+        text-align: right;
+      }
+      table.sysAdminShortcuts th {
+        font-size: 18px;
+        text-align: center;
+      }
+      table.sysAdminShortcuts hr {
+        margin-top:10px;
+        margin-bottom: 10px;
+      } 
+      table.sysAdminShortcuts td input {
+        font-size: 18px;
+      }
+      table.sysAdminShortcuts table th, table.sysAdminShortcuts table td {
+        border-style:none;
+        text-align: center;
       }
 
       #authNotReady {
@@ -838,7 +874,10 @@
                 <li class="nav-item">
                   <a class="nav-link" id="sys-admin-db-tab" data-toggle="tab" href="#sys-admin-db" role="tab" aria-controls="sys-admin-db" aria-selected="false">Database</a>
                 </li>
-                <li class="nav-item"></li>
+                <li class="nav-item">
+                  <a class="nav-link" id="sys-admin-shortcuts-tab" data-toggle="tab" href="#sys-admin-shortcuts" role="tab" aria-controls="sys-admin-shortcuts" aria-selected="false">Shortcuts</a>
+                </li>
+                <li class="nav-item">
                   <a class="nav-link" id="sys-clean-sheet-tab" data-toggle="tab" href="#sys-admin-clean-sheet" role="tab" aria-controls="sys-admin-clean-sheet" aria-selected="false">Clean Sheet of Paper</a>
                 </li>
               </ul>
@@ -907,6 +946,84 @@
                       <div class="dbTableLabel">Consenters</div>
                       <button class="btn btn-primary btn" type="button" onclick="refreshDbTable('consenters')">Load/Refresh</button>
                       <div id="db-table-consenters" style="margin-top:10px;"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="tab-pane fade" id="sys-admin-shortcuts" role="tabpanel" aria-labelledby="sys-admin-shortcuts-tab">
+                  <h3 class="display-7 fw-bold" style="text-align:center; margin-bottom: 20px;">Shortcuts</h3>
+                  <div style="overflow:auto;">
+                    <div class="divSysAdminOption2">
+
+                      <table class="sysAdminShortcuts">
+                        <tr class="open">
+                          <th colspan="2">Setup a new Entity</th>
+                        </tr>
+                        <tr>
+                          <td>Entity Name</td>
+                          <td><input id="txtShortcutEntityName" type="text" class="form-control" value="The School of Hard Knocks"></td>
+                        </tr>
+                        <tr>
+                          <td>Representatives</td>
+                          <td>
+                            <table class="sysAdminShortcuts">
+                              <tr>
+                                <td>Role</td>
+                                <td>Email</td>
+                                <td>Fullname</td>
+                                <td>Phone</td>
+                                <td>Title</td>
+                              </tr>
+                              <tr>
+                                <td>ASP</td>
+                                <td><input id="txtShortcutAspEmail" type="text" class="form-control" value="asp1.random.edu@warhen.work"></td>
+                                <td><input id="txtShortcutAspFullname" type="text" class="form-control" value="Elvis Presley"></td>
+                                <td><input id="txtShortcutAspPhone" type="text" class="form-control" value="+5083339999"></td>
+                                <td><input id="txtShortcutAspTitle" type="text" class="form-control" value="Entertainer"></td>
+                              </tr>
+                              <tr>
+                                <td>AI (1)</td>
+                                <td><input id="txtShortcutAuth1Email" type="text" class="form-control" value="auth1.random.edu@warhen.work"></td>
+                                <td><input id="txtShortcutAuth1Fullname" type="text" class="form-control" value="Sherlock Holmes"></td>
+                                <td><input id="txtShortcutAuth1Phone" type="text" class="form-control" value="+6172334567"></td>
+                                <td><input id="txtShortcutAuth1Title" type="text" class="form-control" value="Detective"></td>
+                              </tr>
+                              <tr>
+                                <td>AI (2)</td>
+                                <td><input id="txtShortcutAuth2Email" type="text" class="form-control" value="auth2.random.edu@warhen.work"></td>
+                                <td><input id="txtShortcutAuth2Fullname" type="text" class="form-control" value="Fred Flintstone"></td>
+                                <td><input id="txtShortcutAuth2Phone" type="text" class="form-control" value="+7812227777"></td>
+                                <td><input id="txtShortcutAuth2Title" type="text" class="form-control" value="Quarry Foreman"></td>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td style="align-items: end;" colspan="2">
+                            <button id="btnShortcutsCreateEntity" class="btn btn-primary">CREATE & STAFF ENTITY</button> 
+                          </td>
+                        </tr>
+                        <tr>
+                          <td colspan="2" style="border-style:none;">&nbsp;</td>
+                        </tr>
+                        <tr class="open">
+                          <th colspan="2">Tear down an entity</th>
+                        </tr>
+                        <tr>
+                          <tr>
+                            <td>Entity</td>
+                            <td>
+                              <select id="lbxSysAdminEntities2" class="form-control">
+                                <option><-- Select One --></option>
+                              </select>
+                            </td>
+                          </tr>
+                        </tr>
+                        <tr>
+                          <td style="align-items: end;" colspan="2">
+                            <button id="btnShortcutsRemoveEntity" class="btn btn-primary">TEAR DOWN ENTITY</button> 
+                          </td>
+                        </tr>
+                      </table>
                     </div>
                   </div>
                 </div>

--- a/lib/lambda/_lib/cognito/CallbackUrls.ts
+++ b/lib/lambda/_lib/cognito/CallbackUrls.ts
@@ -131,11 +131,18 @@ export class CallbackUrlFactory {
       }
     }
     else {
-      addUrl(urls, extendedPathUrl('/sysadmin').href);
-      addUrl(urls, extendedPathUrl('/entity').href);
-      addUrl(urls, extendedPathUrl('/auth-ind').href);
-      addUrl(urls, extendedPathUrl('/consenting').href);
-      addUrl(urls, extendedPathUrl('/amend-entity').href);
+      const addCallbackRoute = (path:string) => {
+        addUrl(urls, extendedPathUrl(path).href);
+        url = extendedPathUrl(path);
+        url.searchParams.set('action', Actions.post_signup);
+        addUrl(urls, url.href);
+      }
+
+      addCallbackRoute('/sysadmin');
+      addCallbackRoute('/entity');
+      addCallbackRoute('/auth-ind');
+      addCallbackRoute('/consenting');
+      addCallbackRoute('/amend-entity');
     }
 
     if(role == Roles.CONSENTING_PERSON) {

--- a/lib/lambda/_lib/dao/dao-entity.ts
+++ b/lib/lambda/_lib/dao/dao-entity.ts
@@ -79,9 +79,11 @@ export function EntityCrud(entityInfo:Entity, _dryRun:boolean=false): DAOEntity 
     else if(entity_name_lower) {
       return await _queryName(readParms) as Entity[]
     }
+    else if(active) {
+      return await _queryActive(active, readParms) as Entity[];
+    }
     else {
-      const _active = active ?? YN.Yes;
-      return await _queryActive(_active, readParms) as Entity[];
+      return await _queryAll(readParms) as Entity[];
     }
   }
 
@@ -109,6 +111,19 @@ export function EntityCrud(entityInfo:Entity, _dryRun:boolean=false): DAOEntity 
     return await loadEntity(retval.Item, convertDates ?? true) as Entity;
   }
 
+  /**
+   * Query for all items regardless of activity status
+   * @param readParms 
+   * @returns 
+   */
+  const _queryAll = async (readParms?:ReadParms):Promise<Entity[]> => {
+    const all = [] as Entity[];
+    const active = await _queryActive(YN.Yes);
+    all.push(...active);
+    const inactive = await _queryActive(YN.No);
+    all.push(...inactive);
+    return all;
+  }
 
   /**
    * Query for items by their activity status

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "cdk": "cdk",
     "deploy": "cdk deploy --all --no-rollback --require-approval never",
     "redeploy": "npm run teardown && npm run deploy",
-    "preteardown": "ts-node bin/PreTeardown.ts",
-    "teardown": "npm run preteardown && cdk destroy --all -f",
+    "pre-teardown": "ts-node bin/pre-teardown.ts",
+    "main-teardown": "bash bin/teardown.sh",
+    "teardown": "npm run pre-teardown && npm run main-teardown",
     "synth": "cdk synth --all 2>&1 | tee cdk.out/ett.template.yaml",
     "clearcache": "sh bin/clearcache.sh",
     "publish": "sh bin/publish.sh"


### PR DESCRIPTION
This feature adds a utility for the system administrator that allows them to:

- Setup an entity in one shot by entering the entity name, the asp, and the two ais and submitting.
The request is received and the following is "setup":
   - Creates an entry in the entities table
   - Creates 3 entries in the invitations table - while the invitation process is bypassed, the entries are made so as to give the normal state in the database of valid invitations having being made and accepted.
   - Creates 3 entries in the users table, asp and the 2 ais.
   - Creates 3 accounts in the cognito user pool, asp and the 2 ais
- Tear down an entity selected from a picklist of entities.
   - Reverses the "setup" steps
   - Purges any items (pdf files) in the exhibit forms bucket that may have been generated while the entity being torn down was in use.