### PR TITLE
Delegates

### DIFF
--- a/frontend/bootstrap/index.htm
+++ b/frontend/bootstrap/index.htm
@@ -583,62 +583,17 @@
           <div id="register-entity-section" class="container-fluid py-5" style="display: none">
             <h3 class="display-7 fw-bold">Entity Registration Form</h3>
             <p class="text-justify fs-4" style="text-align:justify;">
-              <table id='tblEntityName'>
-                <tr>
-                  <td class='tdHeading' colspan=1 style="padding-right:50px;">Name of organization</td>
-                  <td id="tdEntityName" colspan=3 style="width:100%"></td>
-                </tr>
-                <tr><td class='tdSpacing' colspan=4>&nbsp;</td></tr>
-              </table>
-              <table id="tblReAdmin">
-                <tr><td class='trHeading' colspan=4>Administrative support professional<sup>1</sup></td></tr>
-                <tr>
-                  <td id='tdReAdminNameLabel' class='tdHeading'>Name</td>
-                  <td id='tdReAdminName' class='tdEntry'></td>
-                  <td id='tdReAdminTitleLabel' class='tdHeading'>Title</td>
-                  <td id='tdReAdminTitle' class='tdEntry'></td>
-                </tr>
-                <tr>
-                  <td id='tdReAdminPhoneLabel' class='tdHeading'>Phone</td>
-                  <td id='tdReAdminPhone' class='tdEntry'></td>
-                  <td id='tdReAdminEmailLabel' class='tdHeading'>Email</td>
-                  <td id='tdReAdminEmail' class='tdEntry'></td>
-                </tr>
-                <tr><td class='tdSpacing' colspan=4>&nbsp;</td></tr>
-              </table>
-              <table id="tblAuthInd1">
-                <tr><td class='trHeading' colspan=4>Authorized Individual 1<sup>2</sup></td></tr>
-                <tr>
-                  <td id='tdAuthIndName1Label' class='tdHeading'>Name</td>
-                  <td id='tdAuthIndName1' class='tdEntry'></td>
-                  <td id='tdAuthIndTitle1Label' class='tdHeading'>Title</td>
-                  <td id="tdAuthIndTitle1" class='tdEntry'></td>
-                </tr>
-                <tr>
-                  <td id='tdAuthIndPhone1Label' class='tdHeading'>Phone</td>
-                  <td id='tdAuthIndPhone1' class='tdEntry'></td>
-                  <td id='tdAuthIndEmail1Label' class='tdHeading'>Email</td>
-                  <td id='tdAuthIndEmail1' class='tdEntry'></td>
-                </tr>
-                <tr><td class='tdSpacing' colspan=4>&nbsp;</td></tr>
-              </table>
-              <table id="tblAuthInd2">
-                <tr><td class='trHeading'colspan=4 class='tdHeading'>Authorized Individual 2<sup>3</sup></td></tr>
-                <tr>
-                  <td id='tdAuthIndName2Label' class='tdHeading'>Name</td>
-                  <td id='tdAuthIndName2' class='tdEntry'></td>
-                  <td id='tdAuthIndTitle2Label' class='tdHeading'>Title</td>
-                  <td id="tdAuthIndTitle2" class='tdEntry'></td>
-                </tr>
-                <tr>
-                  <td id='tdAuthIndPhone2Label' class='tdHeading'>Phone</td>
-                  <td id='tdAuthIndPhone2' class='tdEntry'></td>
-                  <td id='tdAuthIndEmail2Label' class='tdHeading'>Email</td>
-                  <td id='tdAuthIndEmail2' class='tdEntry'></td>
-                </tr>
-                <tr><td class='tdSpacing' colspan=4>&nbsp;</td></tr>
-              </table>
+              <div>
+                <table id='tblEntityName'>
+                  <tr>
+                    <td class='tdHeading' colspan=1 style="padding-right:50px;">Name of organization</td>
+                    <td id="tdEntityName" colspan=3 style="width:100%"></td>
+                  </tr>
+                  <tr><td class='tdSpacing' colspan=4>&nbsp;</td></tr>
+                </table>
+              </div>
             </p>
+
             <div style="padding-left:20px; display:flex; justify-content: center; text-align:justify; font-style: italic;">
               Registering to use ETT also means that in your official and personal capacities you have read and agree to the ETT Privacy Policy 
               [link] and consent to inclusion of your organization’s name, with or without its Authorized Individuals’ names and contact information 
@@ -2142,148 +2097,197 @@
     }
 
     /**
-     * This function is triggered after a fetch for invitation data..
-     * If the invitation shows a register-entity timestamp, then enable buttons to goto cognito login.
+     * Returns a set of builder functions for the register entity screen fields.
      */
-    function showRegisterEntityScreen(payload) {
+    const getRegisterScreenBuilder = (invitation, parentElement) => {
+      const { email:invEmail, role:invRole, code } = invitation ?? {};
+
+      const insertTextbox = (id, value, parentTd) => {
+        const textbox = document.createElement('input');
+        textbox.type = 'text';
+        textbox.id = id;
+        textbox.className = 'form-control';
+        if(value) textbox.value = value;
+        parentTd.appendChild(textbox);
+      }
+
+      const createUserTable = (user, index, isInvitee) => {
+        const { email, role, fullname, title, phone_number } = user ?? {};
+        const table = document.createElement('table');
+        table.id = role == 'RE_ADMIN' ? 'tblReAdmin' : `tblAuthInd${index-1}`;
+
+        let tr;
+
+        // Add a header row to indicate the user role.
+        const addHeaderRow = () => {
+          const aspDesc = 'Administrative support professional';
+          const aiDesc = 'Authorized Individual';
+          const userDesc = role == 'RE_ADMIN' ? aspDesc : `${aiDesc} ${index-1}`;
+          const tr = document.createElement('tr');
+          table.appendChild(tr);
+          const td = document.createElement('td');
+          td.innerHTML = `${userDesc}<sup>${index}</sup>`;
+          td.className = 'trHeading';
+          td.colSpan = 4;
+          tr.appendChild(td);
+        }
+
+        // Add a row for spacing
+        const addSpacerRow = () => {
+          const tr = document.createElement('tr');
+          table.appendChild(tr);
+          const td = document.createElement('td');
+          td.innerHTML = '&nbsp;';
+          td.className = 'tdSpacing';
+          td.colSpan = 4;
+          tr.appendChild(td);
+        }
+
+        // Add a cell to display the field name.
+        const addFieldNameCell = (html) => {
+          const td = document.createElement('td');
+          tr.appendChild(td);
+          if(isInvitee() && /phone/i.test(html)) {
+            td.innerHTML = phone_number ? html : '&nbsp;';
+          }
+          else {
+            td.innerHTML = html;
+          }
+          td.className = 'tdHeading';
+          return td;
+        }
+
+        // Add a cell to display the field value or a textbox to edit it.
+        const addFieldValueCell = (id, value) => {
+          const td = document.createElement('td');
+          tr.appendChild(td);
+          td.className = 'tdEntry';
+          const isPhone = () => /phone/i.test(id);
+          const isEmail = () => /email/i.test(id);
+
+          if(isInvitee()) {
+            if(isPhone()) {
+              td.innerHTML = value || '&nbsp;';
+            }
+            else if(isEmail()) {
+              if(value) {
+                td.innerHTML = value;
+              }
+              else {
+                const qsEmail = (new URLSearchParams(window.location.search)).get('email') || '';
+                insertTextbox(`txt${id}`, qsEmail, td);
+              }
+            }
+            else if(value) {
+              td.innerHTML = value;
+            }
+            else {
+              insertTextbox(`txt${id}`, '', td);
+            }
+          }
+          else {
+            td.innerHTML = value || '&nbsp;';
+          }
+          return td;
+        }
+
+        // Add row to display the fullname and title fields
+        const addFirstFieldSetRow = () => {
+          tr = document.createElement('tr');
+          table.appendChild(tr);
+          addFieldNameCell('Full Name');
+          addFieldValueCell('Fullname', fullname);
+          addFieldNameCell('Title');
+          addFieldValueCell('Title', title);
+        }
+
+        // Add row to display the phone and email fields
+        const addSecondFieldSetRow = () => {
+          tr = document.createElement('tr');
+          table.appendChild(tr);
+          addFieldNameCell('Phone');
+          addFieldValueCell('Phone', phone_number);
+          addFieldNameCell('Email');
+          addFieldValueCell('Email', email);
+        }
+
+        // Add a table to display the user fields.
+        addHeaderRow();
+        addFirstFieldSetRow();
+        addSecondFieldSetRow();
+        addSpacerRow();
+
+        if( ! parentElement) {
+          parentElement = document.getElementById('tblEntityName').closest('div');
+        }
+        parentElement.appendChild(table);
+        return table;
+      }
+
+      return { insertTextbox, createUserTable };
+    }
+
+    /**
+     * This function is triggered after a fetch for invitation data to render the entity registration screen.
+     */
+    const showRegisterEntityScreen = (payload) => {
       const msg = document.getElementById('apiResponse');
       msg.innerHTML = '';
       try {
-        const { invitation:_invitation, users, entity } = payload ?? {};
-        invitation = _invitation;
-        const { registered_timestamp, email:invEmail, role, entity_name:invEntityName } = invitation ?? {};
-        if(role) {
-          selected_role = role;
-        }
+        const { entity, users=[], invitation } = payload;
+        const { entity_name } = entity ?? {};
+        const { registered_timestamp, role:invRole, email:invEmail, code } = invitation ?? {};
+        const alreadyRegistered = () => invEmail != code;
+        if(invRole) selected_role = invRole;
         const txtSign = document.getElementById('txtEntityRepSig');
         const chk = document.getElementById('chkRegisterEntity');
         const btnSubmit1 = document.getElementById('btnRegisterEntitySubmit');
         const btnSubmit2 = document.getElementById('btnRegisterEntitySubmitAmend');
         const divTerminateEntity = document.getElementById('divTerminateEntity');
 
-        if(selected_role == 'RE_ADMIN') {
-          divTerminateEntity.style.display = 'none';
-          document.getElementById('register-tooltip-1').style.display = 'none';
-        }
-        else {
-          divTerminateEntity.style.display = 'inline';
-        }
-        if(registered_timestamp) {
-          msg.innerHTML = `You registered at ${registered_timestamp}`;
-          chk.checked = true;
-          txtSign.disabled = true;
-          btnSubmit1.disabled = true;
-          btnSubmit2.disabled = true;
-        }
-        else {
-          chk.checked = false;
-          txtSign.value = '';
-          txtSign.disabled = true;
-          btnSubmit1.disabled = true;
-          btnSubmit2.disabled = true;
-        }
+        // Handle the display of buttons and fields at the bottom of the registration form.
+        divTerminateEntity.style.display = selected_role == 'RE_ADMIN' ? 'none' : 'inline';
+        if(selected_role == 'RE_ADMIN') divTerminateEntity.style.display = 'none';
+        if(selected_role == 'RE_ADMIN') document.getElementById('register-tooltip-1').style.display = 'none';
+        if(registered_timestamp) msg.innerHTML = `You registered at ${registered_timestamp}`;
+        chk.checked = registered_timestamp ? true : false;
+        txtSign.disabled = true;
+        btnSubmit1.disabled = true;
+        btnSubmit2.disabled = true;
 
-        const sameUser = user =>  invEmail == user.email;
-        const setField = (user, userfld, basename, index) => {
-          let html = user[userfld] || '';
-          if(userfld == 'entity_name') {
-            index = '';
-          }
-          if( ! user.hasAccount()) {
-            switch(userfld) {
-              case 'email':
-                html = '';
-                break;
-              case 'entity_name':
-                html = '';
-                break;
-            }
-          }
-          if(sameUser(user)) { 
-            if(userfld == 'phone_number') {
-              document.getElementById(`td${basename}${index}`).innerHTML = html;
-              document.getElementById(`td${basename}${index}Label`).innerHTML = '';
-            }
-            else if(userfld == 'entity_name' && entity && invEntityName) {
-              document.getElementById(`td${basename}${index}`).innerHTML = invEntityName;
-              html = invEntityName;
-            }
-            else {
-              if(userfld == 'email') {
-                html = (new URLSearchParams(window.location.search)).get('email') || html;
-              }              
-              html = `<input type="text" class="form-control" id="txt${basename}${index}" value="${html}">`
-            }                  
-          }
-          const td = document.getElementById(`td${basename}${index}`);
-          if(td) {
-            td.innerHTML = html;
-          }
-        }
-        const setFields = (user, basename, index) => {
-          setField(user, 'entity_name', `EntityName`, index||'');
-          setField(user, 'fullname', `${basename}Name`, index||'');
-          setField(user, 'title', `${basename}Title`, index||'');
-          setField(user, 'phone_number', `${basename}Phone`, index||'');
-          setField(user, 'email', `${basename}Email`, index||'');
-          if(user.role == 'RE_AUTH_IND') {
-            document.getElementById('tblAuthInd2').style.display = 'inline';
-          }
-        }
-        
-        document.getElementById(`tblAuthInd1`).style.display = 'none';
-        document.getElementById(`tblAuthInd2`).style.display = 'none';
+        // Get the builder functions for the register entity screen fields
+        const tdEntityName = document.getElementById('tdEntityName');
+        // const { insertTextbox, createUserTable } = getRegisterScreenBuilder(invitation);
+        const parentElement = tdEntityName.closest('div');
+        const { insertTextbox, createUserTable } = getRegisterScreenBuilder(invitation, parentElement);
 
+        // Handle the display of the entity name field if indicated, else assume entity acknowledgement is indicated. 
         if(entity) {
-          document.getElementById('tblEntityName').style.display = 'inline';
-          document.getElementById('tdEntityName').innerHTML = entity.entity_name;
-          document.getElementById('tblAuthInd1').style.display = 'inline'; 
-          let authIndCounter = 0;
-          let aspCounter = 0;
-          if(users && users.length > 0) {
-            users.forEach((user) => {
-              user.hasAccount = () => true;
-              user.entity_name = entity.entity_name;
-              switch(user.role) {
-                case 'RE_ADMIN':
-                  setFields(user, 'ReAdmin');
-                  aspCounter++;
-                  break;
-                case 'RE_AUTH_IND':
-                  setFields(user, 'AuthInd', ++authIndCounter);
-                  break;
-              }
-            });
-          }
-          if(authIndCounter < 2) {
-            if( users.find(user =>  user.email == invitation.email )) {
-              document.getElementById(`tblAuthInd${authIndCounter+1}`).style.display = 'none';
-            }
-            else {
-              let { entity_name, email, code, fullname, title, phone_number } = invitation;
-              setFields({
-                entity_name, email, fullname, title, phone_number, hasAccount: () => email != code
-              }, 'AuthInd', authIndCounter+1);
-            }
-          }
-          if(aspCounter == 0) {
-            let { entity_name, email, code, fullname, title, phone_number } = invitation;
-            setFields({
-              entity_name, email, fullname, title, phone_number, hasAccount: () => email != code
-            }, 'ReAdmin');
-          }
+          tdEntityName.innerHTML = entity_name;
         }
-        else if(role == 'RE_ADMIN') {
-          // document.getElementById('tblEntityName').style.display = 'none';
-          let { entity_name, email, code, fullname, title, phone_number } = invitation;
-          setFields({
-            entity_name, email, fullname, title, phone_number, hasAccount: () => email != code
-          }, 'ReAdmin');
+        else if(invRole == 'RE_ADMIN') {
+          insertTextbox('txtEntityName', entity_name, tdEntityName);
         }
         else {
           showSection('acknowledge-entity');
           return;
         }
+        
+        // Render the asp table first...
+        const asp = users.find(user => user.role == 'RE_ADMIN') ?? { role:'RE_ADMIN' };
+        let isInvitee = () => users.length == 0 || (users.length == 1 && invRole == 'RE_ADMIN' && alreadyRegistered());
+        createUserTable(asp, 1, isInvitee);
+        if(isInvitee()) return;
+
+        // Render the first auth ind table...
+        const authInd1 = users.find(user => user.role == 'RE_AUTH_IND') ?? { role:'RE_AUTH_IND' };
+        isInvitee = () => users.length == 1 || (users.length == 2 && invRole == 'RE_AUTH_IND' && alreadyRegistered());
+        createUserTable(authInd1, 2, isInvitee);
+        if(isInvitee()) return;
+
+        // Render the 2nd auth ind table...
+        const authInd2 = users.length > 2 ? users.find(u => u.role == 'RE_AUTH_IND' && u.email != authInd1.email) : { role:'RE_AUTH_IND' };
+        createUserTable(authInd2, 3, () => true);
       }
       catch(e) {
         msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
@@ -2294,47 +2298,45 @@
     }
 
     /**
-     * Submit entity registration and if successful, navigate to the cognito hosted UI.
+     * Submit to the registration api endpoint the registration details of the invitee.
      */
-    function registerEntity(invitationCode, amend) {
+    const registerEntity = async (invitationCode, amend) => {
       const msg = document.getElementById('apiResponse');
       msg.innerHtml = '';
-      const uri = `${STATIC_PARAMETERS.REGISTER_ENTITY_API_URI}/register/${invitationCode}`;
-      const basename = selected_role == 'RE_ADMIN' ? 'ReAdmin' : 'AuthInd';
-      const getAuthIndIndex = () => $(`#txt${basename}Email1`).length == 1 ? '1' : '2';
-      const index = selected_role == 'RE_ADMIN' ? '' : getAuthIndIndex();
-      const formdata = {
-        email: $(`#txt${basename}Email${index}`).val(),
-        fullname: $(`#txt${basename}Name${index}`).val(),
-        title: $(`#txt${basename}Title${index}`).val()
-      }
-      if(selected_role == 'RE_ADMIN') {
-        formdata.entity_name = $('#txtEntityName').val();
-      }
-      const querystring = Object.keys(formdata).map(key => `${encodeURIComponent(key)}=${encodeURIComponent(formdata[key])}`).join('&');
+      try {
+        const uri = `${STATIC_PARAMETERS.REGISTER_ENTITY_API_URI}/register/${invitationCode}`;
+        const parentDiv = document.getElementById('tblEntityName').closest('div');
+        const formdata = {
+          email: parentDiv.querySelector('#txtEmail').value,
+          fullname: parentDiv.querySelector('#txtFullname').value,
+          title: parentDiv.querySelector('#txtTitle').value,
+        }
+        if(selected_role == 'RE_ADMIN') {
+          formdata.entity_name = parentDiv.querySelector('#txtEntityName').value;
+        }
+        const querystring = Object.keys(formdata).map(key => `${encodeURIComponent(key)}=${encodeURIComponent(formdata[key])}`).join('&');
 
-      fetch(`${uri}?${querystring}`, {
-        method: 'GET',
-        credentials: 'omit',
-        mode: 'cors',
-      })
-      .then(response => response.json())
-      .then((json) => {
-        const { message, payload } = json;
+        document.body.style.cursor = 'progress';
+        const response = await fetch(`${uri}?${querystring}`, {
+          method: 'GET',
+          credentials: 'omit',
+          mode: 'cors',
+        });
+
+        const package = await response.json();
+        document.body.style.cursor = 'default';
+        const { message, payload } = package;
         if(payload.ok) {
-          let email = $('input[type="text"]').filter(function() {
-              return /^txt[^\d]+Email\d*$/.test(this.id);
-          })[0];
-          email = email ? email.value : '';
+          const { email } = formdata;
           signUp(email, amend);
         }
         else {
-          msg.innerHTML = `<pre>${message}</pre>`;
+          msg.innerHTML = `<pre>${JSON.stringify(package, null, 2)}</pre>`;
         }
-      })
-      .catch((e) => {
-        msg.innerHTML = `<pre>${e.message}</pre>`;
-      }); 
+      }
+      catch(e) {
+        msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+      }
     }
 
     /**

--- a/frontend/bootstrap/index.htm
+++ b/frontend/bootstrap/index.htm
@@ -2107,7 +2107,7 @@
         parentTd.appendChild(textbox);
       }
 
-      const createUserTable = (user, index, isInvitee) => {
+      const createUserTable = (user, index, isNewInvitee) => {
         const { email, role, fullname, title, phone_number, delegate } = user ?? {};
         const table = document.createElement('table');
         table.id = role == 'RE_ADMIN' ? 'tblReAdmin' : `tblAuthInd${index-1}`;
@@ -2144,7 +2144,7 @@
         const addFieldNameCell = (html) => {
           const td = document.createElement('td');
           tr.appendChild(td);
-          if(isInvitee() && /phone/i.test(html)) {
+          if(isNewInvitee() && /phone/i.test(html)) {
             td.innerHTML = phone_number ? html : '&nbsp;';
           }
           else {
@@ -2162,7 +2162,7 @@
           const isPhone = () => /phone/i.test(id);
           const isEmail = () => /email/i.test(id);
 
-          if(isInvitee()) {
+          if(isNewInvitee()) {
             if(isPhone()) {
               td.innerHTML = value || '&nbsp;';
             }
@@ -2217,8 +2217,8 @@
           tr.appendChild(td);
           td.className = 'tdEntry';
           td.colSpan = 3;
-          if( ! delegate &&  ! isInvitee()) {
-            td.innerHTML = 'No delegate'
+          if( ! delegate &&  ! isNewInvitee()) {
+            td.innerHTML = email ? 'No delegate' : '&nbsp;';
             return;
           }
 
@@ -2227,7 +2227,7 @@
               const pair = `${label}: ${value}`;
               td.innerHTML = td.innerHTML ? `${td.innerHTML}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;${pair}` : pair;
             }
-            if(isInvitee()) {
+            if(isNewInvitee()) {
               if(value) {
                 buildLabel();
                 return;
@@ -2282,7 +2282,7 @@
             });
           }
 
-          if(isInvitee() && !email) {
+          if(isNewInvitee() && !email) {
             addDelegateCheckbox();
           }
           else {
@@ -2352,22 +2352,28 @@
           showSection('acknowledge-entity');
           return;
         }
-        
+
+        // A new invitee is someone for whom textboxes must be displayed for data entry.
+        const isNewInvitee = (user) => {
+          const { email, role } = user ?? {};
+          if(email) return false;
+          return invEmail == code && role == invRole;
+        }
+
         // Render the asp table first...
         const asp = users.find(user => user.role == 'RE_ADMIN') ?? { role:'RE_ADMIN' };
-        let isInvitee = () => users.length == 0 || (users.length == 1 && invRole == 'RE_ADMIN' && alreadyRegistered());
-        createUserTable(asp, 1, isInvitee);
-        if(isInvitee()) return;
+        const newAspInvitee = isNewInvitee(asp);
+        createUserTable(asp, 1, () => newAspInvitee);
 
         // Render the first auth ind table...
         const authInd1 = users.find(user => user.role == 'RE_AUTH_IND') ?? { role:'RE_AUTH_IND' };
-        isInvitee = () => users.length == 1 || (users.length == 2 && invRole == 'RE_AUTH_IND' && alreadyRegistered());
-        createUserTable(authInd1, 2, isInvitee);
-        if(isInvitee()) return;
+        const newAuthInd1Invitee = newAspInvitee ? false : isNewInvitee(authInd1);
+        createUserTable(authInd1, 2, () => newAuthInd1Invitee);
 
         // Render the 2nd auth ind table...
-        const authInd2 = users.length > 2 ? users.find(u => u.role == 'RE_AUTH_IND' && u.email != authInd1.email) : { role:'RE_AUTH_IND' };
-        createUserTable(authInd2, 3, () => true);
+        const authInd2 = users.find(u => u.role == 'RE_AUTH_IND' && u.email != authInd1.email) ?? { role:'RE_AUTH_IND' };
+        const newAuthInd2Invitee = (newAspInvitee || newAuthInd1Invitee) ? false : isNewInvitee(authInd2);
+        createUserTable(authInd2, 3, () => newAuthInd2Invitee);
       }
       catch(e) {
         msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
@@ -2392,7 +2398,13 @@
           title: parentDiv.querySelector('#txtTitle').value,
         }
         if(selected_role == 'RE_ADMIN') {
-          formdata.entity_name = parentDiv.querySelector('#txtEntityName').value;
+          const txtEntity = parentDiv.querySelector('#txtEntityName');
+          if(txtEntity) {
+            formdata.entity_name = txtEntity.value;
+          }
+          else {
+            formdata.entity_id = entityInfo.entity_id;
+          }
         }
         else {
           const chkDelegate = parentDiv.querySelector('#chkDelegate') ?? { checked: false };

--- a/frontend/bootstrap/index.htm
+++ b/frontend/bootstrap/index.htm
@@ -611,17 +611,13 @@
             <hr style="margin-bottom: 30px;">
             <div style="font-style: italic;">
               <p>
-                <sup>1</sup>Administrative Support Professional who assists and directly works with one or both of the Authorized Individuals, 
-                is accustomed to maintaining confidential and sensitive information, and can administratively support the Registered Entity’s 
-                use of ETT, including submitting requests for disclosures when directed by an Authorized Individual.                
+                <sup>1</sup>Administrative Support Professional who assists and directly works with one or both of the Authorized Individuals, is accustomed to maintaining confidential and sensitive information, and can administratively support the Registered Entity’s use of ETT, including submitting requests for disclosures when directed by an Authorized Individual                
               </p>                
               <p>
-                <sup>2</sup>Person in a senior role that is accustomed to managing confidential and sensitive information, who will directly receive the 
-                completed Disclosure Form information on behalf of the Requesting Registered Entity and will decide who at the Registered 
-                Entity needs the information.                
+                <sup>2</sup>Person in a senior role that is accustomed to managing confidential and sensitive information, who will make Disclosure Requests and directly receive the completed Disclosure Form information on behalf of the Requesting Registered Entity and will decide who at the Registered Entity needs the information                
               </p>                
               <p>
-                <sup>3</sup>Ibid.                
+                <sup>3</sup>These are the contacts who will respond to Disclosure Requests from another ETT-Registered Entity when your organization is disclosing its findings of misconduct against a person who is being considered by the other ETT-Registered Entity. You may input “same as [specify Authorized Individuals or Administrative Support Professional]” it these individuals will fulfill the Disclosure Response Contact role too                
               </p>                
             </div>
             <div style="justify-content: center; border-style:solid; padding:10px; padding-right:25px;">
@@ -2112,7 +2108,7 @@
       }
 
       const createUserTable = (user, index, isInvitee) => {
-        const { email, role, fullname, title, phone_number } = user ?? {};
+        const { email, role, fullname, title, phone_number, delegate } = user ?? {};
         const table = document.createElement('table');
         table.id = role == 'RE_ADMIN' ? 'tblReAdmin' : `tblAuthInd${index-1}`;
 
@@ -2126,7 +2122,8 @@
           const tr = document.createElement('tr');
           table.appendChild(tr);
           const td = document.createElement('td');
-          td.innerHTML = `${userDesc}<sup>${index}</sup>`;
+          const sup = role == 'RE_ADMIN' ? '1' : '2';
+          td.innerHTML = `${userDesc}<sup>${sup}</sup>`;
           td.className = 'trHeading';
           td.colSpan = 4;
           tr.appendChild(td);
@@ -2211,10 +2208,95 @@
           addFieldValueCell('Email', email);
         }
 
+        const addDelegateRow = () => {
+          const { fullname, email, phone_number, title } = delegate ?? {};
+          tr = document.createElement('tr');
+          table.appendChild(tr);
+          addFieldNameCell('Delegate<sup>3</sup>');
+          const td = document.createElement('td');
+          tr.appendChild(td);
+          td.className = 'tdEntry';
+          td.colSpan = 3;
+          if( ! delegate &&  ! isInvitee()) {
+            td.innerHTML = 'No delegate'
+            return;
+          }
+
+          const addDelegateField = (label, value) => {
+            const buildLabel = () => {
+              const pair = `${label}: ${value}`;
+              td.innerHTML = td.innerHTML ? `${td.innerHTML}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;${pair}` : pair;
+            }
+            if(isInvitee()) {
+              if(value) {
+                buildLabel();
+                return;
+              }
+              const textbox = document.createElement('input');
+              textbox.type = 'text';
+              textbox.id = `txtDelegate${label}`;
+              textbox.className = 'form-control';
+              textbox.placeholder = /(title)|(phone)/i.test(label) ? `${label} (optional)` : label;
+              textbox.style.width = '180px';
+              textbox.style.float = 'left';
+              td.appendChild(textbox);
+              return;
+            }
+            buildLabel();
+          }
+
+          const addDelegateFields = () => {
+            addDelegateField('Fullname', fullname);
+            addDelegateField('Email', email);
+            addDelegateField('Title', title);
+            addDelegateField('Phone', phone_number);
+          }
+
+          const addDelegateCheckbox = () => {
+            const div = document.createElement('div');
+            div.style.float = 'left';
+            div.innerHTML = 'Add';
+            div.style.marginTop = '4px';
+            div.style.textAlign = 'right';
+            div.style.width = '60px';
+            td.appendChild(div);
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.id = 'chkDelegate';
+            checkbox.style.float = 'left';
+            checkbox.style.margin = '10px 4px'
+            checkbox.label = 'Not me';
+            td.appendChild(checkbox);
+            checkbox.addEventListener('change', (e) => {
+              if(e.target.checked) {
+                div.innerHTML = 'Remove';
+                addDelegateFields();
+              }
+              else {
+                div.innerHTML = 'Add';
+                const flds = td.querySelectorAll('input[type="text"]');
+                flds.forEach(fld => {
+                  td.removeChild(fld);
+                });
+              }
+            });
+          }
+
+          if(isInvitee() && !email) {
+            addDelegateCheckbox();
+          }
+          else {
+            addDelegateFields();
+          }
+        }
+
         // Add a table to display the user fields.
         addHeaderRow();
         addFirstFieldSetRow();
         addSecondFieldSetRow();
+        if(role == 'RE_AUTH_IND') {
+          addDelegateRow();
+        }
         addSpacerRow();
 
         if( ! parentElement) {
@@ -2257,9 +2339,7 @@
 
         // Get the builder functions for the register entity screen fields
         const tdEntityName = document.getElementById('tdEntityName');
-        // const { insertTextbox, createUserTable } = getRegisterScreenBuilder(invitation);
-        const parentElement = tdEntityName.closest('div');
-        const { insertTextbox, createUserTable } = getRegisterScreenBuilder(invitation, parentElement);
+        const { insertTextbox, createUserTable } = getRegisterScreenBuilder(invitation);
 
         // Handle the display of the entity name field if indicated, else assume entity acknowledgement is indicated. 
         if(entity) {
@@ -2313,6 +2393,23 @@
         }
         if(selected_role == 'RE_ADMIN') {
           formdata.entity_name = parentDiv.querySelector('#txtEntityName').value;
+        }
+        else {
+          const chkDelegate = parentDiv.querySelector('#chkDelegate') ?? { checked: false };
+          if(chkDelegate.checked) {
+            formdata.delegate_email = parentDiv.querySelector('#txtDelegateEmail').value;
+            formdata.delegate_fullname = parentDiv.querySelector('#txtDelegateFullname').value;
+            formdata.delegate_title = parentDiv.querySelector('#txtDelegateTitle').value;
+            formdata.delegate_phone = parentDiv.querySelector('#txtDelegatePhone').value;
+            if( ! formdata.delegate_fullname) {
+              alert('Delegate fullname is required');
+              return;
+            }
+            if( ! formdata.delegate_email) {
+              alert('Delegate email is required');
+              return;
+            }
+          }
         }
         const querystring = Object.keys(formdata).map(key => `${encodeURIComponent(key)}=${encodeURIComponent(formdata[key])}`).join('&');
 
@@ -5571,8 +5668,78 @@
 
         case 'register-entity':
           let payload = { invitation: { role: selected_role }};
-          if( ! localTesting()) {
-            payload = await fetchRegistrationScreenInfo(invitationCode); 
+          if(localTesting()) {
+            payload = {
+              "entity": {
+                "active": "Y",
+                "entity_id": "7d7f004a-a2b4-4d7e-a971-a866dbd9d75f",
+                "create_timestamp": "2025-01-21T19:09:56.517Z",
+                "entity_name": "The School of Rock",
+                "entity_name_lower": "the school of rock",
+                "description": "The School of Rock",
+                "update_timestamp": "2025-01-21T19:09:56.517Z"
+              },
+              "users": [
+                {
+                  "active": "Y",
+                  "entity_id": "7d7f004a-a2b4-4d7e-a971-a866dbd9d75f",
+                  "role": "RE_ADMIN",
+                  "create_timestamp": "2025-01-21T19:09:56.549Z",
+                  "phone_number": "+1234567890",
+                  "email": "asp2.random.edu@warhen.work",
+                  "fullname": "Daffy Duck",
+                  "sub": "b1bb5540-6011-7084-5afb-0d416928ec4d",
+                  "title": "Duck",
+                  "update_timestamp": "2025-01-21T19:09:56.549Z"
+                },
+                {
+                  "active": "Y",
+                  "entity_id": "7d7f004a-a2b4-4d7e-a971-a866dbd9d75f",
+                  "role": "RE_AUTH_IND",
+                  "create_timestamp": "2025-01-21T19:11:07.084Z",
+                  "phone_number": "+1234567890",
+                  "email": "auth3.random.edu@warhen.work",
+                  "fullname": "Sherlock Holmes",
+                  "sub": "515b9580-1041-706c-b2a4-1392dc8c2aa3",
+                  "title": "Detective",
+                  "update_timestamp": "2025-01-21T19:11:07.084Z",
+                  "delegate": {
+                    "fullname": "Donald Duck",
+                    "title": "Bird",
+                    "email": "donald@disney.com",
+                    "phone_number": "+1234567890"
+                  }
+                },
+                // {
+                //   "active": "Y",
+                //   "entity_id": "7d7f004a-a2b4-4d7e-a971-a866dbd9d75f",
+                //   "role": "RE_AUTH_IND",
+                //   "create_timestamp": "2025-01-21T19:12:05.718Z",
+                //   "phone_number": "+1234567890",
+                //   "email": "auth4.random.edu@warhen.work",
+                //   "fullname": "Abraham Lincoln",
+                //   "sub": "d12bd520-7061-7096-f895-a74af980b3b1",
+                //   "title": "President",
+                //   "update_timestamp": "2025-01-21T19:12:05.718Z"
+                // }
+              ],
+              "invitation": {
+                "code": "cfef243b-af25-4085-8839-dc60f0187d3d",
+                "entity_id": "7d7f004a-a2b4-4d7e-a971-a866dbd9d75f",
+                "role": "RE_ADMIN",
+                "entity_name": "The School of Rock",
+                "registered_timestamp": "2025-01-21T19:09:29.487Z",
+                "message_id": "010f01948a441744-edfc9159-6511-4770-a2da-444c7bc21d52-000000",
+                "email": "asp2.random.edu@warhen.work",
+                "fullname": "Daffy Duck",
+                "sent_timestamp": "2025-01-21T19:08:25.860Z",
+                "title": "Duck"
+              },
+              "ok": true
+            }
+          }
+          else {
+            payload = await fetchRegistrationScreenInfo(invitationCode);
           }
           if(payload) {
             showRegisterEntityScreen(payload);

--- a/lib/lambda/_lib/dao/db-update-builder.user.test.ts
+++ b/lib/lambda/_lib/dao/db-update-builder.user.test.ts
@@ -11,6 +11,12 @@ describe('getCommandInputBuilderForUserUpdate', () => {
       role: Roles.CONSENTING_PERSON,
       sub: 'mm_sub_id',
       fullname: 'Mickey Mouse',
+      delegate: {
+        email: 'donald-duck@disney.com',
+        fullname: 'Donald Duck',
+        title: 'Duck of All Trades',
+        phone_number: '123-456-7890'
+      }
     } as User;
 
     const isoString = new Date().toISOString();
@@ -24,16 +30,23 @@ describe('getCommandInputBuilderForUserUpdate', () => {
         ['#sub']: 'sub',
         ['#role']: 'role', 
         ['#fullname']: 'fullname', 
+        ['#delegate']: 'delegate',
         ['#update_timestamp']: 'update_timestamp', 
       },
       ExpressionAttributeValues: {
         [':sub']: { S: 'mm_sub_id' },
         [':role']: { S: 'CONSENTING_PERSON' }, 
         [':fullname']: { S: 'Mickey Mouse' }, 
+        [':delegate']: { M: {
+          'email': { S: 'donald-duck@disney.com' },
+          'fullname': { S: 'Donald Duck' },
+          'title': { S: 'Duck of All Trades' },
+          'phone_number': { S: '123-456-7890' }
+        } },
         [':update_timestamp']: { S: isoString }, 
       },
       // NOTE: fields will be set in the same order as they appear in the entity.UserFields
-      UpdateExpression: 'SET #sub = :sub, #role = :role, #fullname = :fullname, #update_timestamp = :update_timestamp'
+      UpdateExpression: 'SET #sub = :sub, #role = :role, #fullname = :fullname, #delegate = :delegate, #update_timestamp = :update_timestamp'
     } as UpdateItemCommandInput;
 
     Date.prototype.toISOString = () => { return isoString; }

--- a/lib/lambda/_lib/dao/entity.ts
+++ b/lib/lambda/_lib/dao/entity.ts
@@ -21,9 +21,22 @@ export enum UserFields {
   fullname = 'fullname',
   title = 'title',
   phone_number = 'phone_number',
+  delegate = 'delegate',
   create_timestamp = 'create_timestamp',
   update_timestamp = 'update_timestamp',
   active = 'active'
+};
+export enum DelegateFields {
+  fullname = 'fullname',
+  email = 'email',
+  title = 'title',
+  phone_number = 'phone_number'
+};
+export type Delegate = {
+  fullname: string,
+  email: string,
+  title?: string,
+  phone_number?: string
 };
 export type User = {
   email: string,
@@ -33,6 +46,7 @@ export type User = {
   fullname?: string,
   title?: string,
   phone_number?: string,
+  delegate?:Delegate,
   create_timestamp?: string,
   update_timestamp?: string,
   active?: Y_or_N
@@ -128,6 +142,7 @@ export enum InvitationFields {
   message_id = 'message_id',
   fullname = 'fullname',
   title = 'title',
+  delegate = 'delegate',
   registered_timestamp = 'registered_timestamp',
   retracted_timestamp = 'retracted_timestamp',
 }
@@ -141,6 +156,7 @@ export type Invitation = {
   fullname?: string,
   title?: string,
   entity_name?: string,
+  delegate?: Delegate,
   registered_timestamp?: string,
   retracted_timestamp?: string,
 }

--- a/lib/lambda/_lib/invitation/Registration.ts
+++ b/lib/lambda/_lib/invitation/Registration.ts
@@ -48,6 +48,7 @@ export class Registration {
         [InvitationFields.fullname]: invitation.fullname,
         [InvitationFields.title]: invitation.title,
         [InvitationFields.entity_name]: invitation.entity_name,
+        [InvitationFields.delegate]: invitation.delegate
       } as Invitation}) as DAOInvitation;
 
       const output = await dao.update();

--- a/lib/lambda/_lib/invitation/Registration.ts
+++ b/lib/lambda/_lib/invitation/Registration.ts
@@ -41,15 +41,21 @@ export class Registration {
         timestamp = new Date().toISOString();
       }
 
-      const dao = DAOFactory.getInstance({ DAOType: 'invitation', Payload: {
+      const { email, fullname, title, entity_name, delegate } = invitation;
+      const _invitation = {
         code:this.code, 
         [InvitationFields.registered_timestamp]: timestamp,
-        [InvitationFields.email]: invitation.email,
-        [InvitationFields.fullname]: invitation.fullname,
-        [InvitationFields.title]: invitation.title,
-        [InvitationFields.entity_name]: invitation.entity_name,
-        [InvitationFields.delegate]: invitation.delegate
-      } as Invitation}) as DAOInvitation;
+        [InvitationFields.email]: email,
+        [InvitationFields.fullname]: fullname,
+        [InvitationFields.title]: title,
+        [InvitationFields.delegate]: delegate
+      } as Invitation;
+
+      if(entity_name) {
+        _invitation[InvitationFields.entity_name] = entity_name;
+      }
+      
+      const dao = DAOFactory.getInstance({ DAOType: 'invitation', Payload: _invitation}) as DAOInvitation;
 
       const output = await dao.update();
       return true;

--- a/lib/lambda/_lib/pdf/DisclosureFormPage1.ts
+++ b/lib/lambda/_lib/pdf/DisclosureFormPage1.ts
@@ -180,6 +180,8 @@ export class DisclosureFormPage1 extends PdfForm implements IPdfForm {
   private drawAuthorizedIndividual = async (number:string, authInd:User) => {
     let size = 10;
     const { page, page: { basePage, bodyWidth }, font, _return } = this;
+    const { delegate } = authInd;
+    const rep = delegate ?? authInd;
 
     await new Rectangle({
       text: `Authorized Individual #${number}`,
@@ -207,7 +209,7 @@ export class DisclosureFormPage1 extends PdfForm implements IPdfForm {
     basePage.moveRight(fldNameWidth); 
 
     await new Rectangle({
-      text: authInd.fullname ?? '',
+      text: rep.fullname ?? '',
       page,
       align: Align.left,
       valign: VAlign.middle,
@@ -229,7 +231,7 @@ export class DisclosureFormPage1 extends PdfForm implements IPdfForm {
     basePage.moveRight(fldNameWidth);
 
     await new Rectangle({
-      text: authInd.title!,
+      text: rep.title!,
       page,
       align: Align.left,
       valign: VAlign.middle,
@@ -252,7 +254,7 @@ export class DisclosureFormPage1 extends PdfForm implements IPdfForm {
     basePage.moveRight(fldNameWidth); 
 
     await new Rectangle({
-      text: authInd.phone_number! || '',
+      text: rep.phone_number! || '',
       page,
       align: Align.left,
       valign: VAlign.middle,
@@ -274,7 +276,7 @@ export class DisclosureFormPage1 extends PdfForm implements IPdfForm {
     basePage.moveRight(fldNameWidth);
 
     await new Rectangle({
-      text: authInd.email,
+      text: rep.email,
       page,
       align: Align.left,
       valign: VAlign.middle,
@@ -473,7 +475,7 @@ export class DisclosureFormPage1 extends PdfForm implements IPdfForm {
 
 const { argv:args } = process;
 if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/_lib/pdf/DisclosureFormPage1.ts')) {
-
+  
   new DisclosureFormPage1(
     {
       consenter: { 

--- a/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
+++ b/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
@@ -21,7 +21,7 @@ import { EntityToCorrect } from "./correction/EntityCorrection";
 import { Personnel } from "./correction/EntityPersonnel";
 import { DemolitionRecord, EntityToDemolish } from "./Demolition";
 import { DisclosureEmailParms, DisclosureRequestEmail, RecipientListGenerator } from "./DisclosureRequestEmail";
-import { ExhibitFormRequestEmail } from "./ExhibitFormRequestEmail";
+import { ExhibitFormRequest } from "./ExhibitFormRequest";
 
 export enum Task {
   LOOKUP_USER_CONTEXT = 'lookup-user-context',
@@ -315,35 +315,7 @@ export type SendExhibitFormRequestParms = {
  * @returns 
  */
 export const sendExhibitFormRequest = async (parms:SendExhibitFormRequestParms):Promise<LambdaProxyIntegrationResponse> => {
-  let { consenterEmail, constraint, entity_id, linkUri } = parms;
-
-  if( ! linkUri) {
-    const cloudfrontDomain = process.env.CLOUDFRONT_DOMAIN;
-    if( ! cloudfrontDomain) {
-      return errorResponse('Email failure for exhibit form request: CLOUDFRONT_DOMAIN environment variable not set!');
-    }
-    linkUri = `https://${process.env.CLOUDFRONT_DOMAIN}`
-  }
-
-  switch(constraint) {
-    case 'current': case 'other': case 'both':
-      const sent = await new ExhibitFormRequestEmail({ 
-        consenterEmail, 
-        entity_id, 
-        linkUri, 
-        constraint 
-      }).send();
-
-      // Bail out if the email failed
-      if( ! sent) {
-        return errorResponse(`Email failure for exhibit form request: ${JSON.stringify({ consenterEmail, entity_id }, null, 2)}`);
-      }
-      
-      return okResponse('Ok', {});
-      
-    default:
-      return invalidResponse(`Invalid/missing affiliate constraint parameter: ${constraint}`);
-  }
+  return new ExhibitFormRequest(parms).sendEmail();
 }
 
 /**

--- a/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
@@ -1,7 +1,7 @@
 import * as ctx from '../../../../contexts/context.json';
 import { IContext } from "../../../../contexts/IContext";
 import { DAOFactory } from "../../_lib/dao/dao";
-import { Consenter, Entity, ExhibitForm as ExhibitFormData, Role, Roles, User, YN } from "../../_lib/dao/entity";
+import { Consenter, Delegate, Entity, ExhibitForm as ExhibitFormData, Role, Roles, User, YN } from "../../_lib/dao/entity";
 import { EmailParms, sendEmail } from "../../_lib/EmailWithAttachments";
 import { ConsentForm } from "../../_lib/pdf/ConsentForm";
 import { DisclosureForm, DisclosureFormData } from "../../_lib/pdf/DisclosureForm";
@@ -122,7 +122,11 @@ export class RecipientListGenerator {
     // Construct a recipient list for the disclosure request email
     const emailMapper = (user:User, role:Role):string|undefined => {
       if(user.role == role && user.active == YN.Yes) {
-        return user.email;
+        const { email, delegate={} as Delegate } = user;
+        if(delegate.email) {
+          return delegate.email;
+        }
+        return email;
       }
       return undefined;
     }

--- a/lib/lambda/functions/authorized-individual/ExhibitFormRequest.test.ts
+++ b/lib/lambda/functions/authorized-individual/ExhibitFormRequest.test.ts
@@ -1,0 +1,95 @@
+import { SendExhibitFormRequestParms } from "./AuthorizedIndividual";
+import { ExhibitFormRequest } from "./ExhibitFormRequest";
+
+const expectedLink = (expected:string) => {
+  return { test: (parms:SendExhibitFormRequestParms) => {
+    const efr = new ExhibitFormRequest(parms);
+    const link = efr.getLink() as string;
+    expect(link).toEqual(expected);
+  }};
+}
+
+const defaultParms = {
+  consenterEmail: 'cp1@warhen.work',
+  entity_id: 'ea14dcfd-2f5a-40e1-9bc1-48a3afeec996',
+  linkUri: 'https://d227na12o3l3dd.cloudfront.net',
+  constraint: 'other',
+} as SendExhibitFormRequestParms;
+
+
+describe('ExhibitFormRequest', () => {
+
+  it('Should properly form an exhibit form request link for bootstrap exhibit form "backdoor"', async () => {
+    const parms = { ...defaultParms, linkUri: `${defaultParms.linkUri}/bootstrap/index.htm` };
+    let expected = 'https://d227na12o3l3dd.cloudfront.net/bootstrap/consenting/add-exhibit-form/other/index.htm';
+
+    // Test without trailing slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/bootstrap/index.htm`;
+    expectedLink(expected).test(parms);
+
+    // Test with trailing slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/bootstrap/index.htm/`;
+    expectedLink(expected).test(parms);
+
+    // Test without index.htm and trailing slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/bootstrap`;
+    expectedLink(expected).test(parms);
+
+    // Test without index.htm 
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/bootstrap/`;
+    expectedLink(expected).test(parms);
+    
+    // Test with a querystring
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/bootstrap/index.htm?foo=bar`;
+    expectedLink(`${expected}?foo=bar`).test(parms);
+    
+    // Test with a querystring and a trailing slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/bootstrap/index.htm/?foo=bar`;
+    expectedLink(`${expected}?foo=bar`).test(parms);
+    
+    // Test with a querystring and no file name
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/bootstrap?foo=bar`;
+    expectedLink(`${expected}?foo=bar`).test(parms);
+    
+    // Test with a querystring and no file name and a trailing slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/bootstrap/?foo=bar`;
+    expectedLink(`${expected}?foo=bar`).test(parms);
+  });
+
+  it('Should properly form an exhibit form request link for cloudfront for the standard website exhibit form "backdoor"', async () => {
+    const parms = { ...defaultParms };
+    const expected = 'https://d227na12o3l3dd.cloudfront.net/consenting/add-exhibit-form/other';
+
+    // Test without trailing slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net`;
+    expectedLink(expected).test(parms);
+
+    // Test with trailing slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/`;
+    expectedLink(expected).test(parms);
+
+    // Test with index.html
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/index.html`;
+    expectedLink(expected).test(parms);
+
+    // Test with index.html and slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/index.html/`;
+    expectedLink(expected).test(parms);
+    
+    // Test with a querystring and no file name
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net?foo=bar`;
+    expectedLink(`${expected}?foo=bar`).test(parms);
+    
+    // Test with a querystring and no file name and a trailing slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/?foo=bar`;
+    expectedLink(`${expected}?foo=bar`).test(parms);
+    
+    // Test with a querystring and a file name
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/index.html?foo=bar`;
+    expectedLink(`${expected}?foo=bar`).test(parms);
+    
+    // Test with a querystring and a file name and a trailing slash
+    parms.linkUri = `https://d227na12o3l3dd.cloudfront.net/index.html/?foo=bar`;
+    expectedLink(`${expected}?foo=bar`).test(parms);
+  });
+});

--- a/lib/lambda/functions/authorized-individual/ExhibitFormRequest.ts
+++ b/lib/lambda/functions/authorized-individual/ExhibitFormRequest.ts
@@ -1,0 +1,115 @@
+import { LambdaProxyIntegrationResponse } from "../../../role/AbstractRole";
+import { errorResponse, invalidResponse, okResponse } from "../../Utils";
+import { SendExhibitFormRequestParms } from "./AuthorizedIndividual";
+import { ExhibitFormRequestEmail } from "./ExhibitFormRequestEmail";
+
+export class ExhibitFormRequest {
+  private parms: SendExhibitFormRequestParms;
+
+  constructor(parms:SendExhibitFormRequestParms) {
+    this.parms = parms;
+  }
+
+  /**
+   * If no link is provided, attempt to construct it from what can be found in environment variables.
+   * @returns 
+   */
+  private getDefaultLinkUri = ():string|void => {
+    const cloudfrontDomain = process.env.CLOUDFRONT_DOMAIN;
+    if( ! cloudfrontDomain) return;
+    return `https://${process.env.CLOUDFRONT_DOMAIN}`
+  }
+
+  /**
+   * Test to see if the basic href indicates the bootstrap website - a truthy return value means it does.
+   * @param url 
+   * @returns 
+   */
+  private tryAsBootstrapLink = (url:URL):string|void => {
+    const { parms: { constraint } } = this;
+    const { pathname:path } = url;
+
+    // Bail out if the url does not indicate a bootstrap link
+    const isABootstrapLink = () => path.endsWith('/bootstrap') || path.startsWith('/bootstrap/')
+    if( ! isABootstrapLink()) return;
+
+    let pathParts = path.split('/');
+    // Strip out index.htm if it is there. It should be at the end, not the middle, but account for that anyway
+    pathParts = pathParts.filter(part => part && part != 'index.htm');
+
+    url.pathname = `${pathParts.join('/')}/consenting/add-exhibit-form/${constraint}/index.htm`;
+    return url.href;
+  }
+
+  /**
+   * Test to see if the basic href indicates the standard website - a truthy return value means it does.
+   * @param url 
+   * @returns 
+   */
+  private tryAsStandardWebsiteLink = (url:URL):string|void => {
+    const { parms: { constraint } } = this;
+    const { pathname:path } = url;
+
+    let pathParts = path.split('/');
+    // Strip out any html file if it is there. It should be at the end, not the middle, but account for that anyway
+    pathParts = pathParts.filter(part => part && /^\w+\.((htm)|(html))$/i.test(part) == false);
+
+    url.pathname = `${pathParts.join('/')}/consenting/add-exhibit-form/${constraint}`;
+    return url.href;
+  }
+
+  /**
+   * Get the href of the link to be sent in the exhibit form request email.
+   * @returns 
+   */
+  public getLink = (): string|void => {
+    let { parms: { linkUri }, getDefaultLinkUri, tryAsBootstrapLink, tryAsStandardWebsiteLink } = this;
+    const href = linkUri ?? getDefaultLinkUri();
+    if( ! href) return;
+    const url = new URL(href);
+
+    let link = tryAsBootstrapLink(url);
+    if(link) return link;
+
+    // Test to see if the basic href indicates the standard website - a truthy return value means it does.
+    link = tryAsStandardWebsiteLink(url);
+    if(link) return link;
+
+    // There was something wrong with the basic href;
+    return;
+  }
+
+  /**
+   * Send the exhibit form request email
+   * @returns 
+   */
+  public sendEmail = async ():Promise<LambdaProxyIntegrationResponse> => {
+    let { parms: { consenterEmail, constraint, entity_id }, getLink } = this;
+
+    const linkUri = getLink();
+  
+    if( ! linkUri) {
+      return errorResponse('Email failure for exhibit form request: Cannot determine link to put in the email!');
+    }
+  
+    switch(constraint) {
+      case 'current': case 'other': case 'both':
+        const sent = await new ExhibitFormRequestEmail({ 
+          consenterEmail, 
+          entity_id, 
+          linkUri, 
+          constraint 
+        }).send();
+  
+        // Bail out if the email failed
+        if( ! sent) {
+          return errorResponse(`Email failure for exhibit form request: ${JSON.stringify({ consenterEmail, entity_id }, null, 2)}`);
+        }
+        
+        return okResponse('Ok', {});
+        
+      default:
+        return invalidResponse(`Invalid/missing affiliate constraint parameter: ${constraint}`);
+    }
+  }
+}

--- a/lib/lambda/functions/authorized-individual/ExhibitFormRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/ExhibitFormRequestEmail.ts
@@ -11,7 +11,6 @@ export type ExhibitFormRequestEmailParms = {
   entity_id:string;
   linkUri:string;
   constraint: 'current' | 'other' | 'both';
-  filename?: string
 }
 
 export class ExhibitFormRequestEmail {
@@ -22,7 +21,7 @@ export class ExhibitFormRequestEmail {
   }
 
   public send = async ():Promise<boolean> => {
-    let { parms: { consenterEmail, entity_id, linkUri, constraint, filename }} = this;
+    let { parms: { consenterEmail, entity_id, linkUri, constraint }} = this;
     if((linkUri ?? '').endsWith('/')) {
       linkUri = linkUri.substring(0, linkUri.length -1); // Clip off trailing '/'
     }
@@ -46,19 +45,18 @@ export class ExhibitFormRequestEmail {
       return false;
     }
   
+    // Get who the email will say it is from
     const context:IContext = <IContext>ctx;
-    let link = `${linkUri}/consenting/add-exhibit-form/${constraint}`;
-    if(filename) {
-      link = link + '/' + filename;
-    }
+    const from = `noreply@${context.ETT_DOMAIN}`;
+    
     return sendEmail({
       subject: `ETT Exhibit Form Request`,
       to: [ consenterEmail ],
       message: `Thankyou ${consenterFullName} for registering with the Ethical Tranparency Tool.<br>` +
         `${entity_name} is requesting you take the next step and fill out a prior contacts or "exhibit" form.<br>` +
         `Follow the link provided below to log in to your ETT account and to access the form:` + 
-        `<p>${link}</p>`,
-      from: `noreply@${context.ETT_DOMAIN}`,
+        `<p>${linkUri}</p>`,
+      from,
       attachments: []
     } as EmailParms);  
   }

--- a/lib/lambda/functions/authorized-individual/MockObjects.ts
+++ b/lib/lambda/functions/authorized-individual/MockObjects.ts
@@ -16,7 +16,13 @@ export const bugsbunny = {
   update_timestamp,
   fullname: 'Bug Bunny',
   phone_number: '+6172224444',
-  title: 'Rabbit'
+  title: 'Rabbit',
+  delegate: {
+    email: 'delegate1@anytown-university.com',
+    fullname: 'Delegate One',
+    phone_number: '+6173335555',
+    title: 'Bugs Bunnys Delegate'
+  }
 } as User;
 export const bugbunny_invitation = {
   code: 'abc123',

--- a/lib/lambda/functions/cognito/PostSignup.ts
+++ b/lib/lambda/functions/cognito/PostSignup.ts
@@ -352,8 +352,16 @@ export const scrapeUserValuesFromInvitations = async (invitationLookup:RoleInvit
     return null;
   }
 
-  // There should be only one result, but multiple results just means a SYS_ADMIN sent a subsequent invitation
-  // to the same person before that person had a chance to register to and setup an account against the first invitation.
+  // There should usually be only one result, but multiple results just means a subsequent invitation was sent
+  // to the same person before that person had a chance to register to and setup an account against the first 
+  // invitation. Or, the corresponding user was removed as part of an entity ammendment, and then invited back
+  // again (there would now be more than one invitation for the same email address).
+
+  // Return the most recent invitation
+  invitations.sort((a, b) => {
+    return new Date(b.sent_timestamp).getTime() - new Date(a.sent_timestamp).getTime();
+  });
+  
   return invitations[0];
 }
 
@@ -365,7 +373,7 @@ export const scrapeUserValuesFromInvitations = async (invitationLookup:RoleInvit
 const { argv:args } = process;
 if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/functions/cognito/PostSignup.ts')) {
 
-  const task = 'scrape' as 'handler' | 'scrape';
+  const task = 'handler' as 'handler' | 'scrape';
 
   (async () => {
     switch(task) {
@@ -384,21 +392,21 @@ if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/functions
         const mockEvent = {
           "version": "1",
           "region": "us-east-2",
-          "userPoolId": "us-east-2_FFxJkLmaJ",
-          "userName": "51bbc580-30e1-7065-2eb0-1ac0362e7d60",
+          "userPoolId": "us-east-2_sOpeEXuYJ",
+          "userName": "812be5f0-7061-70a0-1deb-6de1a938431d",
           "callerContext": {
               "awsSdkVersion": "aws-sdk-unknown-unknown",
-              "clientId": "1c74v2fe28ti22gf4fala0ce62"
+              "clientId": "5me7av3klctvios49o3cr6ap1h"
           },
           "triggerSource": "PostConfirmation_ConfirmSignUp",
           "request": {
               "userAttributes": {
-                  "sub": "51bbc580-30e1-7065-2eb0-1ac0362e7d60",
+                  "sub": "812be5f0-7061-70a0-1deb-6de1a938431d",
                   "email_verified": "true",
                   "cognito:user_status": "CONFIRMED",
                   "phone_number_verified": "false",
-                  "phone_number": "+6172224444",
-                  "email": "asp.au.edu@warhen.work"
+                  "phone_number": "+1234567890",
+                  "email": "auth3.random.edu@warhen.work"
               }
           },
           "response": {}

--- a/lib/lambda/functions/cognito/PostSignup.ts
+++ b/lib/lambda/functions/cognito/PostSignup.ts
@@ -280,7 +280,7 @@ export const handler = async (_event:any) => {
 const addUserToDatabase = async (event:PostSignupEventType, role:Role, invitation:Invitation):Promise<User|undefined> => {
   const { sub, email, phone_number } = event.request.userAttributes;
 
-  let { entity_id, fullname, title } = invitation;
+  let { entity_id, fullname, title, delegate } = invitation;
 
   const user = {
     [UserFields.email]: email,
@@ -289,7 +289,8 @@ const addUserToDatabase = async (event:PostSignupEventType, role:Role, invitatio
     [UserFields.title]: title,
     [UserFields.phone_number]: phone_number,
     [UserFields.sub]: sub,
-    [UserFields.role]: role
+    [UserFields.role]: role,
+    [UserFields.delegate]: delegate
   } as User;
 
   const daoUser = DAOFactory.getInstance({ DAOType: 'user', Payload: user }) as DAOUser;

--- a/lib/lambda/functions/signup/EntityRegistration.test.ts
+++ b/lib/lambda/functions/signup/EntityRegistration.test.ts
@@ -377,12 +377,12 @@ describe(`Entity Registration lambda trigger: handler ${Task.REGISTER}`, () => {
     });
   });
 
-  it('Should NOT attempt to update if entity_name querystring parameter is missing for RE_ADMIN', async () => {
+  it('Should NOT attempt to update if both entity_name and entity_id querystring parameter is missing for RE_ADMIN', async () => {
     goodCode = code;
     alreadyRegistered = false;
     await invokeAndAssert({
       _handler:handler, code, task: Task.REGISTER,
-      queryStringParameters: { entity_id:bugs.entity_id, email:bugs.email, fullname:bugs.fullname },
+      queryStringParameters: { email:bugs.email, fullname:bugs.fullname, title:bugs.title },
       expectedResponse: {
         statusCode: 400,
         outgoingBody: {
@@ -423,7 +423,7 @@ describe(`Entity Registration lambda trigger: handler ${Task.REGISTER}`, () => {
     await invokeAndAssert({
       _handler:handler, code, task: Task.REGISTER,
       queryStringParameters: { 
-        entity_id:bugs.entity_id, 
+        entity_id:undefined, // Make sure this is undefined
         email:bugs.email, 
         fullname:bugs.fullname, 
         entity_name: goodNonWaitingRoomInvitationPayload.entity_name

--- a/lib/lambda/functions/signup/EntityRegistration.ts
+++ b/lib/lambda/functions/signup/EntityRegistration.ts
@@ -55,6 +55,10 @@ export const handler = async(event:any):Promise<LambdaProxyIntegrationResponse> 
 
       // Return a list of users who have already gone through the registration process for the entity and exist in the users table.
       case Task.LOOKUP_ENTITY:
+        if(entity_id == ENTITY_WAITING_ROOM) {
+          // Must be an RE_ADMIN who has not registered yet (no entity created yet).
+          return okResponse('Ok', { entity:null, users:[], invitation });
+        }
         const dao = DAOFactory.getInstance({
           DAOType: "user",
           Payload: { entity_id } as User

--- a/lib/lambda/functions/signup/EntityRegistration.ts
+++ b/lib/lambda/functions/signup/EntityRegistration.ts
@@ -81,8 +81,11 @@ export const handler = async(event:any):Promise<LambdaProxyIntegrationResponse> 
         if( ! event.queryStringParameters) {
           return invalidResponse('Bad Request: Missing querystring parameters');
         }
+        // NOTE: entity_id usually won't be set for an ASP as they are creating a new entity by entity_name.
+        // However, if it is set, it is a signal that the entity is already created and the asp is replacing 
+        // a prior ASP asp part of an entity amendment.
         let { 
-          email, fullname, title, entity_name, delegate_fullname, delegate_email, delegate_title, delegate_phone 
+          email, fullname, title, entity_id:entityId, entity_name, delegate_fullname, delegate_email, delegate_title, delegate_phone 
         } = event.queryStringParameters;
 
         if( ! email) {
@@ -91,7 +94,7 @@ export const handler = async(event:any):Promise<LambdaProxyIntegrationResponse> 
         if( ! fullname) {
           return invalidResponse('Bad Request: Missing fullname querystring parameter');
         }
-        if( ! entity_name && (role == Roles.RE_ADMIN || role == Roles.SYS_ADMIN) ) {
+        if( ! entityId && ! entity_name && (role == Roles.RE_ADMIN || role == Roles.SYS_ADMIN) ) {
            return invalidResponse('Bad Request: Missing entity_name querystring parameter');
         }
         let delegate = undefined;
@@ -123,7 +126,7 @@ export const handler = async(event:any):Promise<LambdaProxyIntegrationResponse> 
         if(registered_timestamp) {
           return okResponse(`Ok: Already registered at ${registered_timestamp}`);
         }
-        if(role == Roles.RE_ADMIN) {
+        if(role == Roles.RE_ADMIN && ! entityId) {
           if( await registration.entityNameAlreadyInUse(entity_name)) {
             return invalidResponse(`Bad Request: The specified name: "${entity_name}", is already in use.`)
           }


### PR DESCRIPTION
This feature adds "delegates" to the entity registration of authorized users.
That is, in addition to entering their own personal details _(fullname, title, and email)_, the authorized individual can also add the details of an individual who will be receiving disclosure forms on their behalf.
This means that when an affiliate named by the consenting individual in their exhibit forms receives the email requesting them to fill out and return a disclosure form, the return email address is specified to be that of the delegate _(not the authorized individual)_.