### PR TITLE
Ai asp updates

### DIFF
--- a/frontend/bootstrap/index.htm
+++ b/frontend/bootstrap/index.htm
@@ -264,7 +264,7 @@
         padding-top:10px;
       }
 
-      #divConsenterCorrect > div {
+      #divConsenterCorrect > div, #divReAdminCorrect > div, #divAuthIndCorrect > div {
         float:left;
         margin-top: 10px;
         margin-left: 10px;
@@ -272,18 +272,23 @@
         font-size: 22px;
         max-width:60%;
       }
-      #divConsenterCorrect > div[label="true"] {
+      #divConsenterCorrect > div[label="true"], #divReAdminCorrect > div[label="true"], #divAuthIndCorrect > div[label="true"] {
         font-weight:bold;
         clear:both;
-        width: 150px;
+        width: 250px;
         text-align: right;
         font-size: 18px;
         padding-top: 4px;
       }
-      #divConsenterCorrect > div > p {
+      #divConsenterCorrect > div > p, #divReAdminCorrect > div > p, #divAuthIndCorrect > div > p {
         margin-top: 10px;
         font-style: italic;
         font-size: 16px;
+      }
+      #divConsenterCorrect > div[label="true"] > span, #divReAdminCorrect > div[label="true"] > span, #divAuthIndCorrect > div[label="true"] > span {
+        font-weight: normal;
+        font-style: italic;
+        font-size: 14px;
       }
 
       span[data-toggle="tooltip"] {
@@ -1070,7 +1075,10 @@
               <h3 class="display-7 fw-bold">Welcome <span id="RE_ADMIN_username"></span></h3>
               <ul class="nav nav-tabs" id="reAdmin" role="tablist">
                 <li class="nav-item">
-                  <a class="nav-link active" id="re-admin-entity-link" data-toggle="tab" href="#re-admin-entity" role="tab" aria-controls="re-admin-entity" aria-selected="true">Entity/Organization</a>
+                  <a class="nav-link active" id="re-admin-correct-link" data-toggle="tab" href="#re-admin-correct" role="tab" aria-controls="re-admin-correct" aria-selected="true">Your Details</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" id="re-admin-entity-link" data-toggle="tab" href="#re-admin-entity" role="tab" aria-controls="re-admin-entity" aria-selected="true">Entity/Organization</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" id="asp-request-disclosures-tab" data-toggle="tab" href="#asp-request-disclosures" role="tab" aria-controls="asp-request-disclosures-link" aria-selected="true">Request Disclosure Forms</a>
@@ -1085,7 +1093,66 @@
               </div>
 
               <div class="tab-content" id="reAdminContent">
-                <div class="tab-pane fade show active" id="re-admin-entity" role="tabpanel" aria-labelledby="re-admin-entity-link">
+
+                <div class="tab-pane fade show active" id="re-admin-correct" role="tabpanel" aria-labelledby="re-admin-correct-link">
+                  <h3 class="display-7 fw-bold">Your Details</h3>
+                  <div id="divReAdminCorrect" class="divSysAdminOption" style="width:100%; height:300px;">
+                    <div label="true">Full Name:</div>
+                    <div>
+                      <span id="re-admin-correct-fullname">[Insert Username]</span>
+                    </div>
+                    <div label="true">Title:</div>
+                    <div>
+                      <span id="re-admin-correct-title">[Insert Title]</span>
+                    </div>
+                    <div label="true">Email Address:</div>
+                    <div>
+                      <span id="re-admin-correct-email">[Insert Email]</span>
+                      <p>
+                        PLEASE NOTE: Corrections to your email address will trigger a signout from your account and an email sent to 
+                        your new email address with a temporary password. Login again with this password and you will be 
+                        prompted with a password reset screen. You may use your original password if you like.
+                    </p>
+                    </div>
+                    <div label="true">Phone Number:<br><span>(digits only, prepend with "+")</span></div>
+                    <div>
+                      <span id="re-admin-correct-phone">[Insert Phone]</span>
+                    </div>
+                    <div label="true">&nbsp;</div>
+                    <div style="margin-top:30px;">
+                                       
+                      <!-- Button trigger modal -->
+                      <button class="btn btn-primary btn-lg" data-bs-toggle="modal" data-bs-target="#correctReAdminBackdrop">EDIT</button>
+                      <!-- Modal -->
+                      <div class="modal fade" id="correctReAdminBackdrop" data-bs-backdrop="static" data-bs-keyboard="false" aria-labelledby="correctReAdminBackdropLabel" aria-hidden="true">
+                        <div class="modal-dialog  modal-dialog-scrollable">
+                          <div class="modal-content">
+                            <div class="modal-header">
+                              <h5 class="modal-title" id="correctReAdminBackdropLabel">Edit your account details</h5>
+                            </div>
+                            <div class="modal-body" style="text-align:left; overflow:auto;">
+                              <div style="clear:both; margin-top:10px;">Full Name (first middle last)</div>
+                              <div><input type="text" class="form-control" id="txtReAdminEditFullname"></div>
+                              <div style="clear:both; margin-top:10px;">Title</div>
+                              <div><input type="text" class="form-control" id="txtReAdminEditTitle"></div>
+                              <div style="clear:both; margin-top:10px;">Email Address</div>
+                              <div><input type="text" class="form-control" id="txtReAdminEditEmail"></div>
+                              <div style="clear:both; margin-top:10px;">Phone Number</div>
+                              <div><input type="text" class="form-control" id="txtReAdminEditPhone"></div>
+                            </div>
+                            <div class="modal-footer">
+                              <button id="btnReAdminCorrect" class="btn btn-primary" data-bs-dismiss="modal">SUBMIT CHANGES</button>
+                              &nbsp;
+                              <button class="btn btn-primary" data-bs-dismiss="modal">Cancel</button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="tab-pane fade" id="re-admin-entity" role="tabpanel" aria-labelledby="re-admin-entity-link">
                   <div id="divCreateEntity" style="margin-top: 40px; overflow:auto;">
                     <h5 class="display-7 fw-bold" style="text-align:center; margin-top:20px;">Invite authorized individuals</h5>
                     <div id="divReAdminEntityName" class="divSysAdminOption" style="text-align: right;">
@@ -1111,6 +1178,7 @@
                     <div id="divPendingInvitations" style="padding-top:50px; float:left; clear:both;"></div>
                   </div>                  
                 </div>
+                
                 <div class="tab-pane fade" id="asp-request-disclosures" role="tabpanel" aria-labelledby="asp-request-disclosures-tab">
                   <div id="disclosureRequest" style="margin-top: 40px;">
                     <table class="disclosureRequest" style="width:fit-content; margin: 0 auto;">
@@ -1135,6 +1203,7 @@
                     </table>
                   </div>
                 </div>
+
               </div>
             </div>
 
@@ -1147,7 +1216,10 @@
 
               <ul class="nav nav-tabs" id="authInd" role="tablist">
                 <li class="nav-item">
-                  <a class="nav-link active" id="auth-request-exhibits-tab" data-toggle="tab" href="#auth-request-exhibits" role="tab" aria-controls="auth-request-exhibits-link" aria-selected="true">Request Exhibit Forms</a>
+                  <a class="nav-link active" id="auth-request-correct-tab" data-toggle="tab" href="#auth-request-correct" role="tab" aria-controls="auth-request-correct-link" aria-selected="true">Your Details</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" id="auth-request-exhibits-tab" data-toggle="tab" href="#auth-request-exhibits" role="tab" aria-controls="auth-request-exhibits-link" aria-selected="true">Request Exhibit Forms</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" id="auth-request-disclosures-tab" data-toggle="tab" href="#auth-request-disclosures" role="tab" aria-controls="auth-request-disclosures-link" aria-selected="true">Request Disclosure Forms</a>
@@ -1166,8 +1238,98 @@
               </div>
 
               <div class="tab-content" id="authIndContent">
-                <div class="tab-pane fade show active" id="auth-request-exhibits" role="tabpanel" aria-labelledby="auth-request-exhibits-tab">
-                  
+
+                <div class="tab-pane fade show active" id="auth-request-correct" role="tabpanel" aria-labelledby="auth-request-correct-tab">
+                  <h3 class="display-7 fw-bold">Your Details</h3>
+                  <div id="divAuthIndCorrect" class="divSysAdminOption" style="width:100%; height:450px;">
+
+                    <!-- Authorized Individual -->
+                    <div label="true">Full Name:</div>
+                    <div>
+                      <span id="re-auth-ind-correct-fullname">[Insert Username]</span>
+                    </div>
+                    <div label="true">Title:</div>
+                    <div>
+                      <span id="re-auth-ind-correct-title">[Insert Title]</span>
+                    </div>
+                    <div label="true">Email Address:</div>
+                    <div>
+                      <span id="re-auth-ind-correct-email">[Insert Email]</span>
+                      <p>
+                        PLEASE NOTE: Corrections to your email address will trigger a signout from your account and an email sent to 
+                        your new email address with a temporary password. Login again with this password and you will be 
+                        prompted with a password reset screen. You may use your original password if you like.
+                    </p>
+                    </div>
+                    <div label="true">Phone Number:<br><span>(digits only, prepend with "+")</span></div>
+                    <div>
+                      <span id="re-auth-ind-correct-phone">[Insert Phone]</span>
+                    </div>
+
+                    <!-- Delegate -->
+                    <div label="true">Delegate Full Name:</div>
+                    <div>
+                      <span id="re-auth-ind-correct-delegate-fullname">[Insert Username]</span>
+                    </div>
+                    <div label="true">Delegate Title:</div>
+                    <div>
+                      <span id="re-auth-ind-correct-delegate-title">[Insert Title]</span>
+                    </div>
+                    <div label="true">Delegate Email Address:</div>
+                    <div>
+                      <span id="re-auth-ind-correct-delegate-email">[Insert Email]</span>
+                    </div>
+                    <div label="true">Delegate Phone Number:</div>
+                    <div>
+                      <span id="re-auth-ind-correct-delegate-phone">[Insert Phone]</span>
+                    </div>
+
+
+                    <div label="true">&nbsp;</div>
+                    <div style="margin-top:30px;">
+                                       
+                      <!-- Button trigger modal -->
+                      <button class="btn btn-primary btn-lg" data-bs-toggle="modal" data-bs-target="#correctReAuthIndBackdrop">EDIT</button>
+                      <!-- Modal -->
+                      <div class="modal fade" id="correctReAuthIndBackdrop" data-bs-backdrop="static" data-bs-keyboard="false" aria-labelledby="correctReAuthIndBackdropLabel" aria-hidden="true">
+                        <div class="modal-dialog  modal-dialog-scrollable">
+                          <div class="modal-content">
+                            <div class="modal-header">
+                              <h5 class="modal-title" id="correctReAuthIndBackdropLabel">Edit your account details</h5>
+                            </div>
+                            <div class="modal-body" style="text-align:left; overflow:auto;">
+                              <div style="clear:both; margin-top:10px;">Full Name (first middle last)</div>
+                              <div><input type="text" class="form-control" id="txtReAuthIndEditFullname"></div>
+                              <div style="clear:both; margin-top:10px;">Title</div>
+                              <div><input type="text" class="form-control" id="txtReAuthIndEditTitle"></div>
+                              <div style="clear:both; margin-top:10px;">Email Address</div>
+                              <div><input type="text" class="form-control" id="txtReAuthIndEditEmail"></div>
+                              <div style="clear:both; margin-top:10px;">Phone Number</div>
+                              <div><input type="text" class="form-control" id="txtReAuthIndEditPhone"></div>
+
+                              <div style="clear:both; margin-top:10px;">Delegate Full Name (first middle last)</div>
+                              <div><input type="text" class="form-control" id="txtReAuthIndEditDelegateFullname"></div>
+                              <div style="clear:both; margin-top:10px;">Delegate Title</div>
+                              <div><input type="text" class="form-control" id="txtReAuthIndEditDelegateTitle"></div>
+                              <div style="clear:both; margin-top:10px;">Delegate Email Address</div>
+                              <div><input type="text" class="form-control" id="txtReAuthIndEditDelegateEmail"></div>
+                              <div style="clear:both; margin-top:10px;">Delegate Phone Number</div>
+                              <div><input type="text" class="form-control" id="txtReAuthIndEditDelegatePhone"></div>
+                              
+                            </div>
+                            <div class="modal-footer">
+                              <button id="btnReAuthIndCorrect" class="btn btn-primary" data-bs-dismiss="modal">SUBMIT CHANGES</button>
+                              &nbsp;
+                              <button class="btn btn-primary" data-bs-dismiss="modal">Cancel</button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="tab-pane fade" id="auth-request-exhibits" role="tabpanel" aria-labelledby="auth-request-exhibits-tab">                  
                   <p style="margin-top:40px; margin-bottom:15px; font-weight: bold; font-size: 20px;">
                     What affiliate information are you requesting from the consenting individual?</span> 
                   </p>
@@ -1199,6 +1361,7 @@
                   </div>
 
                 </div>
+
                 <div class="tab-pane fade" id="auth-request-disclosures" role="tabpanel" aria-labelledby="auth-request-disclosures-tab">
                   <div id="disclosureRequest" style="margin-top: 40px;">
                     <table class="disclosureRequest" style="width:fit-content; margin: 0 auto;">
@@ -1223,11 +1386,12 @@
                     </table>
                   </div>
                 </div>
+
                 <div class="tab-pane fade" id="auth-amend-entity" role="tabpanel" aria-labelledby="auth-amend-entity-tab">
                   <div id="amendEntity" style="margin-top: 40px; overflow:auto;">
                     <div>
                       You can amend <span name="spanAmendEntityCurrentName" style="font-weight:bold;"></span> by modifying its name, or removing any 
-                      of its representatives, ncluding yourself. For removals, you can simply click the "Amend" button 
+                      of its representatives, including yourself. For removals, you can simply click the "Amend" button 
                       adjacent to the corresponding individual. If you do this, you can continue normal operation for 
                       30 days with the vacancy, but <span name="spanAmendEntityCurrentName" style="font-weight:bold;"></span> will be terminated in 
                       the ETT system if no replacement registers by then. Optionally, you can also type the email address 
@@ -1305,7 +1469,7 @@
                           prompted with a password reset screen. You may use your original password if you like.
                         </p>
                       </div>
-                      <div label="true">Cell Phone:</div>
+                      <div label="true">Phone Number:</div>
                       <div>
                         <span id="consenter-correct-phone">[Insert Phone]</span>
                       </div>
@@ -1329,7 +1493,7 @@
                                 <div><input type="text" class="form-control" id="txtConsentEditLastName"></div>
                                 <div style="clear:both; margin-top:10px;">Email Address</div>
                                 <div><input type="text" class="form-control" id="txtConsentEditEmail"></div>
-                                <div style="clear:both; margin-top:10px;">Cell Phone</div>
+                                <div style="clear:both; margin-top:10px;">Phone Number</div>
                                 <div><input type="text" class="form-control" id="txtConsentEditPhone"></div>
                                 <!--
                                 <div style="clear:both; margin-top:10px;">Please type your full name <span style="font-size: 10px;">(first, middle, last)</span> to digitally sign this Consent Form:</div>
@@ -3256,6 +3420,37 @@
       return consenterInfo;
     }
 
+    const setEntityRepDetails = (role1) => {
+      const { email, fullname, title, phone_number, role:role2, delegate } = userContext ?? {};
+      const { name:role3 } = AccessJwtCookie.getRole() ?? {};
+      const role = role1 || role2 || role3;
+      const prefix1 = role == 'RE_ADMIN' ? 're-admin' : 're-auth-ind';
+      const prefix2 = role == 'RE_ADMIN' ? 'ReAdmin' : 'ReAuthInd';
+      const setLabel = (id, val) => document.getElementById(id).innerHTML = val;
+      const setField = (id, val) => document.getElementById(id).value = val;
+      
+      setLabel(`${prefix1}-correct-fullname`, fullname);
+      setLabel(`${prefix1}-correct-email`, email);
+      setLabel(`${prefix1}-correct-phone`, phone_number);
+      setLabel(`${prefix1}-correct-title`, title);
+      setField(`txt${prefix2}EditFullname`, fullname);
+      setField(`txt${prefix2}EditEmail`, email);
+      setField(`txt${prefix2}EditPhone`, phone_number);
+      setField(`txt${prefix2}EditTitle`, title);
+
+      if(role == 'RE_AUTH_IND') {
+        const { fullname, email, phone_number, title } = delegate || {};
+        setLabel(`${prefix1}-correct-delegate-fullname`, fullname ?? '');
+        setLabel(`${prefix1}-correct-delegate-email`, email ?? '');
+        setLabel(`${prefix1}-correct-delegate-phone`, phone_number ?? '');
+        setLabel(`${prefix1}-correct-delegate-title`, title ?? '');
+        setField(`txt${prefix2}EditDelegateFullname`, fullname ?? '');
+        setField(`txt${prefix2}EditDelegateEmail`, email ?? '');
+        setField(`txt${prefix2}EditDelegatePhone`, phone_number ?? '');
+        setField(`txt${prefix2}EditDelegateTitle`, title ?? '');
+      }
+    }
+
     /**
      * Register consent.
      */
@@ -3315,6 +3510,16 @@
       alert('Consent form sent');
     }
 
+    const validatePhoneNumber = (phone_number) => {
+      if( ! /^\+[1-9]\d{1,14}$/.test(phone_number)) {
+        alert(`"${phone_number}" is not a valid phone number\n` +
+          'Correct format: ^\+[1-9]\d{1,14}$'
+        );
+        return false;
+      }
+      return true;
+    }
+
     /**
      * Submit corrections to the consenter consent form information. NOTE: Not implemented on the backend (pending client discussion)
      */
@@ -3326,10 +3531,7 @@
       const lastname = document.getElementById('txtConsentEditLastName').value;
       const phone_number = document.getElementById('txtConsentEditPhone').value;
 
-      if( ! /^\+[1-9]\d{1,14}$/.test(phone_number)) {
-        alert(`"${phone_number}" is not a valid phone number\n` +
-          'Correct format: ^\+[1-9]\d{1,14}$'
-        );
+      if( ! validatePhoneNumber(phone_number)) {
         return;
       }
       
@@ -3347,6 +3549,115 @@
           }
         }
       );
+    }
+
+    const correctEntityRep = async () => {
+      const { email, fullname, title, phone_number, role:role1, delegate } = userContext ?? {};
+      const { email:delegate_email, fullname:delegate_fullname, title:delegate_title, phone_number:delegate_phone_number } = delegate ?? {};
+      const { name:role2 } = AccessJwtCookie.getRole() ?? {};
+      const role = role1 || role2;
+      const prefix = role == 'RE_ADMIN' ? 'ReAdmin' : 'ReAuthInd';
+
+      const _fullname = document.getElementById(`txt${prefix}EditFullname`).value;
+      if( ! _fullname) { alert('Fullname required'); setEntityRepDetails(); return; }
+
+      const new_email = document.getElementById(`txt${prefix}EditEmail`).value;
+      if( ! new_email) { alert('Email address required'); setEntityRepDetails(); return; }
+      
+      const _phone_number = document.getElementById(`txt${prefix}EditPhone`).value;
+      if( ! _phone_number) { alert('Phone number required'); setEntityRepDetails(); return; }
+      
+      const _title = document.getElementById(`txt${prefix}EditTitle`).value;
+      if( ! _title) { alert('Title required'); setEntityRepDetails(); return; }
+
+      const _delegate_fullname = document.getElementById(`txt${prefix}EditDelegateFullname`).value;
+      const _delegate_email = document.getElementById(`txt${prefix}EditDelegateEmail`).value;     
+      const _delegate_phone_number = document.getElementById(`txt${prefix}EditDelegatePhone`).value;      
+      const _delegate_title = document.getElementById(`txt${prefix}EditDelegateTitle`).value;
+      const someDelegateEntries = () => {
+        return _delegate_fullname || _delegate_email || _delegate_phone_number || _delegate_title;
+      }
+      if(someDelegateEntries() && ! _delegate_fullname) { alert('Delegate fullname required'); setEntityRepDetails(); return; }
+      if(someDelegateEntries() && ! _delegate_email) { alert('Delegate email address required'); setEntityRepDetails(); return; }
+      if(someDelegateEntries() && ! _delegate_phone_number) { alert('Delegate phone number required'); setEntityRepDetails(); return; }
+      if(someDelegateEntries() && ! _delegate_title) { alert('Delegate title required'); setEntityRepDetails(); return; }
+      
+      if( ! validatePhoneNumber(phone_number)) { setEntityRepDetails(); return; }
+
+      let changeDetected = false;
+      changeDetected ||= _fullname != fullname;
+      changeDetected ||= new_email.toLowerCase() != email.toLowerCase();
+      changeDetected ||= _phone_number != phone_number;
+      changeDetected ||= _title != title;
+      changeDetected ||= _delegate_fullname != delegate_fullname;
+      changeDetected ||= _delegate_email != delegate_email;
+      changeDetected ||= _delegate_phone_number != delegate_phone_number;
+      changeDetected ||= _delegate_title != delegate_title;
+
+      if( ! changeDetected) { alert('No changes detected'); return; }
+
+      const submitUpdate = async (task, parameters, successCallback) => {
+        const msg = document.getElementById('apiResponse');
+        msg.innerHTML = '';
+        try {
+          const { role } = parameters
+          const response = await fetch(apiUri(role), {
+            method: 'GET',
+            mode: 'cors',
+            credentials: 'include',
+            headers: {
+              'Authorization': `Bearer ${AccessJwtCookie.getJwt()}`,
+              'Content-Type': 'application/json',
+              [STATIC_PARAMETERS.PAYLOAD_HEADER]: JSON.stringify({ task, parameters })
+            }
+          });
+
+          const package = await response.json();
+          const { message, payload } = package;
+          if(payload.ok) {
+            if(successCallback) {
+              successCallback();
+            }
+          }
+          else {
+            msg.innerHTML = `<pre>${message}</pre>`;
+          }
+        }
+        catch(e) {
+          msg.innerHTML = `<pre>${JSON.stringify(e, Object.getOwnPropertyNames(e), 2)}</pre>`;
+        }
+      }
+      
+      const task = 'correct-entity-rep';
+      const parameters = { 
+        email, 
+        new_email: new_email.toLowerCase(),
+        entity_id: userContext.entity.entity_id,
+        fullname: _fullname, 
+        title: _title, 
+        phone_number: _phone_number, 
+        role
+      };
+      if(someDelegateEntries()) {
+        parameters.delegate = {
+          email: _delegate_email.toLowerCase(),
+          fullname: _delegate_fullname,
+          title: _delegate_title,
+          phone_number: _delegate_phone_number
+        }
+      }
+      const callback = () => {
+        if(new_email != email) {
+          alert('Your account has been deleted.\n\nPlease check the inbox of your new email address for an invitation to re-register.');
+          signOut();
+        }
+        else {
+          alert('Update complete');
+          location.reload();
+        }
+      }
+
+      await submitUpdate(task, parameters, callback);
     }
 
     /**
@@ -4258,15 +4569,17 @@
         const entity_id = 'abc123';
         const entity_name = 'The Hughs Corporation';
         const asp = { 
-          user: { email:'kong@skull.island.com', fullname:'King Kong', title:'Head Honcho', role:'RE_ADMIN', active:'Y' },
+          user: { email:'kong@skull.island.com', fullname:'King Kong', title:'Head Honcho', phone_number:'+16172223333', role:'RE_ADMIN', active:'Y' },
           invitation: { code:'abc123', entity_id, role:'RE_ADMIN', entity_name, email:'abc123', sent_timestamp: '2024-12-23T20:25:23.092Z' }
         };
-        const ai1 = { 
-          user: { email:'mary@disney.com', fullname:'Mary Poppins', title:'Nannie', role:'RE_AUTH_IND', active:'Y' },
+        const ai1 = {
+          user: { email:'mary@disney.com', fullname:'Mary Poppins', title:'Nannie', phone_number:'+16173334444', role:'RE_AUTH_IND', active:'Y', delegate: {
+            email:'churchill@uk.gov', fullname:'Winston Churchill', title:'Prime Minister', phone_number:'+16173334444'
+          }},
           invitation: { code:'def456', entity_id, role:'RE_AUTH_IND', entity_name, email:'def456', sent_timestamp: '2024-12-24T20:25:23.092Z' }
         };
         const ai2 = { 
-          user: { email:'mickey@disney.com', fullname:'Mickey Mouse', title:'Entertainer', role:'RE_AUTH_IND', active:'Y' },
+          user: { email:'mickey@disney.com', fullname:'Mickey Mouse', title:'Entertainer', phone_number:'+16174445555', role:'RE_AUTH_IND', active:'Y' },
           invitation: { code:'ghi789', entity_id, role:'RE_AUTH_IND', entity_name, email:'ghi789', sent_timestamp: '2024-12-24T20:25:23.438Z' }
         }
 
@@ -4288,9 +4601,9 @@
 
         if(selected_role == 'RE_ADMIN') {
           users = users.filter(u => u.role != 'RE_ADMIN');
-          const { fullname, email, title, role } = asp.user;
+          const { fullname, email, title, role, phone_number } = asp.user;
           userContext = {
-            fullname, email, title, role,          
+            fullname, email, title, role, phone_number,       
             entity: { entity_id, entity_name, users, pendingInvitations, totalUserCount:users.length+1 }
           }
           setName({ name:selected_role, fullname:'Administrative Support Person' }, { getDisplayName:() => fullname ?? email });
@@ -4301,9 +4614,9 @@
             thisAi = 'mickey';
           }
           users = users.filter(u => u.email.startsWith(thisAi) == false);
-          const { fullname, email, title, role } = ai1.user;
+          const { fullname, email, title, role, phone_number, delegate } = ai1.user;
           userContext = {
-            fullname, email, title, role,           
+            fullname, email, title, role, phone_number, delegate,         
             entity: { entity_id, entity_name, users, pendingInvitations, totalUserCount:users.length+1 }
           }
           setName({ name:selected_role, fullname:'Authorized Individual' }, { getDisplayName:() => fullname ?? email });
@@ -5632,6 +5945,12 @@
       document.getElementById('btnConsenterCorrect').addEventListener('click', () => {
         correctConsenter();
       });
+      document.getElementById('btnReAdminCorrect').addEventListener('click', () => {
+        correctEntityRep();
+      });
+      document.getElementById('btnReAuthIndCorrect').addEventListener('click', () => {
+        correctEntityRep();
+      });
       document.getElementById('txtExhibitSignature').addEventListener('keyup', () => {
         toggleHighlight(event.srcElement);
       });
@@ -5835,6 +6154,7 @@
                 dashboard.querySelectorAll(`#disclosureRequest input`).forEach(i => i.disabled = true);
                 dashboard.querySelectorAll(`#disclosureRequest button`).forEach(b => b.disabled = true);
               }
+              setEntityRepDetails();
               break;
 
             case 'RE_AUTH_IND':
@@ -5855,6 +6175,13 @@
                 dashboard.querySelectorAll(`#amendEntity button`).forEach(b => b.disabled = true);
                 dashboard.querySelectorAll(`#amendEntity input`).forEach(i => i.disabled = true);
 
+                // Re-enable the controls for the "Your Details" tab
+                dashboard.querySelector(`#auth-request-correct`).style.color = ''
+                dashboard.querySelectorAll(`#auth-request-correct input`).forEach(i => i.disabled = false);
+                dashboard.querySelectorAll(`#auth-request-correct button`).forEach(b => b.disabled = false);
+                dashboard.querySelectorAll(`#auth-request-correct div`).forEach(d => d.style.color = '');
+                dashboard.querySelectorAll(`#auth-request-correct label`).forEach(l => l.style.color = '');
+
                 // Re-enable the controls for the amend entity tab
                 dashboard.querySelector(`#auth-amend-entity`).style.color = ''
                 dashboard.querySelectorAll(`#auth-amend-entity input`).forEach(i => i.disabled = false);
@@ -5862,6 +6189,8 @@
                 dashboard.querySelectorAll(`#auth-amend-entity div`).forEach(d => d.style.color = '');
                 dashboard.querySelectorAll(`#auth-amend-entity label`).forEach(l => l.style.color = '');
               }
+
+              setEntityRepDetails();
 
               const checkConsenterListing = async () => {
                 const exhibitsTabFocus = document.getElementById('auth-request-exhibits').className.includes('show');

--- a/lib/lambda/_lib/BlankSheetOfPaper.ts
+++ b/lib/lambda/_lib/BlankSheetOfPaper.ts
@@ -140,7 +140,7 @@ export const deletePendingInvitations = async (region:string, dryRun:boolean):Pr
   });
 
   // Get a list of sysadmins (these will be the only items in the users table left after the purge).
-  let sysAdmins = await UserCrud({ entity_id:ENTITY_WAITING_ROOM } as User).read() as User[];
+  let sysAdmins = await UserCrud({ userinfo: { entity_id:ENTITY_WAITING_ROOM } as User }).read() as User[];
   sysAdmins = sysAdmins.filter(user => user.role == Roles.SYS_ADMIN);
 
   /**

--- a/lib/lambda/_lib/EntityAutomation.ts
+++ b/lib/lambda/_lib/EntityAutomation.ts
@@ -131,7 +131,7 @@ export class EntityToAutomate {
     }
     user.sub = sub;
     user.entity_id = entity_id;
-    await UserCrud(user).create();
+    await UserCrud({ userinfo:user }).create();
 
     if( ! createInvitations) return;
 

--- a/lib/lambda/_lib/EntityAutomation.ts
+++ b/lib/lambda/_lib/EntityAutomation.ts
@@ -19,8 +19,9 @@ export class EntityToAutomate {
   private entity:Entity;
   private asps = [] as User[];
   private ais = [] as User[];
+  private createInvitations:boolean;
 
-  constructor(entityName:string, ) {
+  constructor(entityName:string, createInvitations:boolean=false) {
     this.entityName = entityName;
   }
 
@@ -82,7 +83,7 @@ export class EntityToAutomate {
   private sampledUsers = [] as User[];
 
   private createUser = async (user:User) => {
-    const { entity: { entity_id }, entityName, sampledUsers } = this;
+    const { entity: { entity_id }, entityName, sampledUsers, createInvitations } = this;
     const { email, role } = user;
 
     // This should be enough sample users
@@ -132,7 +133,9 @@ export class EntityToAutomate {
     user.entity_id = entity_id;
     await UserCrud(user).create();
 
-    // Create invitations as if they had been sent, accepted, and used to mark registration date.
+    if( ! createInvitations) return;
+
+    // Create invitations as if they had been sent, accepted, and used to mark registration date.    
     const now = new Date().toISOString();
     await InvitationCrud({
       code: uuidv4(),

--- a/lib/lambda/_lib/dao/dao-user-migration.test.ts
+++ b/lib/lambda/_lib/dao/dao-user-migration.test.ts
@@ -8,7 +8,7 @@ jest.mock('../../_lib/dao/dao.ts', () => {
     __esModule: true,
     DAOFactory: {
       getInstance: jest.fn().mockImplementation((parms:any) => {
-        const dao = UserCrud(parms.Payload as User);
+        const dao = UserCrud({ userinfo: parms.Payload as User });
         return {
           read: async ():Promise<any> => {
             return new Promise((resolve, reject) => {

--- a/lib/lambda/_lib/dao/dao.ts
+++ b/lib/lambda/_lib/dao/dao.ts
@@ -60,7 +60,7 @@ export class DAOFactory {
           throw new Error(`User crud error: Invalid Y/N active field value specified in ${JSON.stringify(parms, null, 2)} as ${role}: ${active}`);
         }
         
-        return UserCrud(parms.Payload as User);
+        return UserCrud({ userinfo: parms.Payload as User });
         
       case 'entity':
         var { active } = parms.Payload as Entity;

--- a/lib/lambda/_lib/dao/db-update-builder.user.ts
+++ b/lib/lambda/_lib/dao/db-update-builder.user.ts
@@ -9,7 +9,7 @@ import { User, UserFields } from "./entity";
  * @param user 
  * @returns 
  */
-export const userUpdate = (TableName:string, user:User):Builder => {
+export const userUpdate = (TableName:string, user:User, removableDelegate:boolean=false):Builder => {
   const buildUpdateItemCommandInput = () => {
     if( ! user.update_timestamp) {
       user.update_timestamp = new Date().toISOString();
@@ -30,6 +30,10 @@ export const userUpdate = (TableName:string, user:User):Builder => {
       fieldset.push({ [`#${fld}`]: `:${fld}`})
     }
     item.UpdateExpression = `SET ${fieldset.map((o:any) => { return getFldSetStatement(o); }).join(', ')}`
+    if( ! user[UserFields.delegate] && removableDelegate) {
+      // Absence of a delegate means it should be removed if it exists
+      item.UpdateExpression +=  ` REMOVE ${UserFields.delegate}`;
+    }
     return item;
   } 
   return { buildUpdateItemCommandInput };

--- a/lib/lambda/_lib/invitation/Invitation.ts
+++ b/lib/lambda/_lib/invitation/Invitation.ts
@@ -361,7 +361,7 @@ if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/_lib/invi
     process.env.CLOUDFRONT_DOMAIN = cloudfrontDomain;
 
     // Get the inviter
-    const inviters = await UserCrud({ email:inviterEmail } as User).read() as User[];
+    const inviters = await UserCrud({ userinfo: { email:inviterEmail } as User }).read() as User[];
     if(inviters.length == 0) {
       log(`${inviterEmail} not found!`);
       return;

--- a/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
+++ b/lib/lambda/functions/authorized-individual/AuthorizedIndividual.ts
@@ -21,7 +21,7 @@ import { BucketDisclosureForm } from "../consenting-person/BucketItemDisclosureF
 import { BucketExhibitForm } from "../consenting-person/BucketItemExhibitForm";
 import { BucketItemMetadata, ExhibitFormsBucketEnvironmentVariableName, ItemType } from "../consenting-person/BucketItemMetadata";
 import { DisclosureRequestReminderLambdaParms, RulePrefix } from "../delayed-execution/targets/SendDisclosureRequestReminder";
-import { lookupEntity, retractInvitation, sendEntityRegistrationForm } from "../re-admin/ReAdminUser";
+import { correctUser, lookupEntity, retractInvitation, sendEntityRegistrationForm } from "../re-admin/ReAdminUser";
 import { EntityToCorrect } from "./correction/EntityCorrection";
 import { Personnel } from "./correction/EntityPersonnel";
 import { DemolitionRecord, EntityToDemolish } from "./Demolition";
@@ -40,6 +40,7 @@ export enum Task {
   INVITE_USER = 'invite-user',
   RETRACT_INVITATION = 'retract-invitation',
   SEND_REGISTRATION = 'send-registration',
+  CORRECTION = 'correct-entity-rep',
   PING = 'ping'
 };
 
@@ -118,6 +119,9 @@ export const handler = async (event:any):Promise<LambdaProxyIntegrationResponse>
              
         case Task.RETRACT_INVITATION:
           return await retractInvitation(parameters.code);
+
+        case Task.CORRECTION:
+          return await correctUser(parameters);
           
         case Task.PING:
           return okResponse('Ping!', parameters);

--- a/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
+++ b/lib/lambda/functions/authorized-individual/DisclosureRequestEmail.ts
@@ -143,7 +143,7 @@ export class RecipientListGenerator {
   public generate = async ():Promise<Recipients> => {
     const { entity_id, affiliateEmail, emailType } = this;
     // Get all users for the entity
-    const users = (await UserCrud({ entity_id } as User).read() as User[])
+    const users = (await UserCrud({ userinfo: { entity_id } as User }).read() as User[])
       .filter(user => user.active == YN.Yes);
 
     // Construct a recipient list for the disclosure request email

--- a/lib/lambda/functions/authorized-individual/correction/EntityCorrection.ts
+++ b/lib/lambda/functions/authorized-individual/correction/EntityCorrection.ts
@@ -59,7 +59,7 @@ export class EntityToCorrect {
     await entityCrud.update();
 
     // Obtain all users of the entity
-    const entityUsers = (await UserCrud({ entity_id:now.entity_id } as User).read() as User[])
+    const entityUsers = (await UserCrud({ userinfo: { entity_id:now.entity_id } as User }).read() as User[])
       .filter(user => user.active == YN.Yes);
 
     // Obtain the user who is making the correction
@@ -155,12 +155,12 @@ export const scheduleStaleEntityVacancyHandler = async (entity:Entity, role:Role
     const { STALE_AI_VACANCY, STALE_ASP_VACANCY } = ConfigNames;
     const { entity_id, entity_name } = entity ?? {};
     const lambdaInput = { entity_id } as StaleVacancyLambdaParms;
-    const delayedTestExecution = new DelayedLambdaExecution(functionArn, lambdaInput);
+    const delayedExecution = new DelayedLambdaExecution(functionArn, lambdaInput);
     const staleAfter = role == Roles.RE_ADMIN ? STALE_ASP_VACANCY : STALE_AI_VACANCY;
     let waitTime = (await configs.getAppConfig(staleAfter)).getDuration();
     waitTime += 60; // Event bridge seems to trigger early at times by anywhere up to 18 seconds, so tack on an extra minute.
     const timer = EggTimer.getInstanceSetFor(waitTime, PeriodType.SECONDS);
-    await delayedTestExecution.startCountdown(timer, `${RulePrefix}: ${entity_name}`);
+    await delayedExecution.startCountdown(timer, `${RulePrefix}: ${entity_name}`);
   }
   else {
     console.error(`Cannot schedule ${RulePrefix}: ${envVarName} variable is missing from the environment!`);

--- a/lib/lambda/functions/authorized-individual/correction/EntityPersonnel.ts
+++ b/lib/lambda/functions/authorized-individual/correction/EntityPersonnel.ts
@@ -76,7 +76,7 @@ export class Personnel {
       this.entity_id = replacer.entity_id;
     }
     else if(replacerEmail) {
-      const lookupResult = await UserCrud({ email:replacerEmail } as User).read() as User[];
+      const lookupResult = await UserCrud({ userinfo: { email:replacerEmail } as User }).read() as User[];
       if(lookupResult.length > 1) {
         throw new Error(`${replacerEmail} is a member of more than one registered entity: ${
           JSON.stringify(lookupResult.map(user => user.entity_id), null, 2)
@@ -95,7 +95,7 @@ export class Personnel {
 
     // Load the current users in the entity from the database
     if(users.length == 0) {
-      const _users = await UserCrud({ entity_id } as User).read() as User[];
+      const _users = await UserCrud({ userinfo: { entity_id } as User }).read() as User[];
       if(_users.length == 0) {
         throw new Error(`The following entity has no users: ${entity_id}`);
       }
@@ -184,7 +184,7 @@ export class Personnel {
         return;
       }
       const { email, entity_id } = replaceable;
-      await UserCrud({ email, entity_id, active:YN.No } as User).update();
+      await UserCrud({ userinfo: { email, entity_id, active:YN.No } as User }).update();
 
       // Remove any invitations the user may have been issued
       await InvitationCrud({ email, entity_id} as Invitation).Delete();

--- a/lib/lambda/functions/cognito/PostSignup.ts
+++ b/lib/lambda/functions/cognito/PostSignup.ts
@@ -254,7 +254,7 @@ export const handler = async (_event:any) => {
   // that will terminate the entity if the remaining user(s) do not register within the time dictated by policy.
   if((role == Roles.RE_ADMIN || role == Roles.RE_AUTH_IND) && invitation) {
     const { entity_id, entity_name } = invitation as Invitation;
-    const activeUsers = (await UserCrud({ entity_id } as User).read() as User[]).filter(u => u.active == YN.Yes);
+    const activeUsers = (await UserCrud({ userinfo: { entity_id } as User }).read() as User[]).filter(u => u.active == YN.Yes);
     const asps = activeUsers.filter(u => u.role == Roles.RE_ADMIN);
     const ais = activeUsers.filter(u => u.role == Roles.RE_AUTH_IND);
     const configs = new Configurations();

--- a/lib/lambda/functions/cognito/PreAuthentication.ts
+++ b/lib/lambda/functions/cognito/PreAuthentication.ts
@@ -45,9 +45,9 @@ export const handler = async (_event:any) => {
 
       const { email, email_verified, 'cognito:user_status':status } = event?.request?.userAttributes;
 
-      if(status == 'FORCE_CHANGE_PASSWORD' && role == Roles.CONSENTING_PERSON) {
-        /**
-         * In this circumstance, an existing consenter is changing their email address, which means that the
+      if(status == 'FORCE_CHANGE_PASSWORD') {
+          /**
+         * In this circumstance, an existing user/consenter is changing their email address, which means that the
          * corresponding database entry is pending and happens AFTER cognito account creation. Also:
          *   1) The cognito account will NOT be in a confirmed status. Thus we do not proceed further and run
          *      into any confirmation validation checks which are non-applicable in this scenario

--- a/lib/lambda/functions/consenting-person/correction/CorrectionFormEmail.ts
+++ b/lib/lambda/functions/consenting-person/correction/CorrectionFormEmail.ts
@@ -23,7 +23,7 @@ export class ConsenterCorrectionEmail {
     const context:IContext = <IContext>ctx;
     const { oldConsenter: {firstname, middlename, lastname }, correctionForm } = this;
     const fullname = PdfForm.fullName(firstname, middlename, lastname);
-    const users = (await UserCrud({ entity_id } as User).read() ?? []) as User[];
+    const users = (await UserCrud({ userinfo: { entity_id } as User }).read() ?? []) as User[];
 
     // Get the first AI of the entity as the "to" addressee
     const firstAI = users.find(user => user.active == YN.Yes && user.role == Roles.RE_AUTH_IND);

--- a/lib/lambda/functions/consenting-person/correction/ExhibitCorrectionEmail.ts
+++ b/lib/lambda/functions/consenting-person/correction/ExhibitCorrectionEmail.ts
@@ -109,7 +109,7 @@ export class ExhibitCorrectionEmail {
 
     // Get the email recipients
     if( ! this._users) {
-      this._users = (await UserCrud({ entity_id } as User).read() ?? []) as User[];
+      this._users = (await UserCrud({ userinfo: { entity_id } as User }).read() ?? []) as User[];
     }
 
     const { _users: users } = this;

--- a/lib/lambda/functions/re-admin/Correction.ts
+++ b/lib/lambda/functions/re-admin/Correction.ts
@@ -1,0 +1,255 @@
+import { UserType } from "@aws-sdk/client-cognito-identity-provider";
+import { IContext } from "../../../../contexts/IContext";
+import { DelayedExecutions } from "../../../DelayedExecution";
+import { CognitoStandardAttributes, UserAccount } from "../../_lib/cognito/UserAccount";
+import { EntityCrud } from "../../_lib/dao/dao-entity";
+import { UserCrud } from "../../_lib/dao/dao-user";
+import { Delegate, DelegateFields, Entity, Roles, User, UserFields } from "../../_lib/dao/entity";
+import { error, log, lookupCloudfrontDomain } from "../../Utils";
+import { scheduleStaleEntityVacancyHandler } from "../authorized-individual/correction/EntityCorrection";
+
+export class EntityRepToCorrect {
+  private correctable:User;
+  private lookup:boolean;
+  private message:string;
+
+  constructor(correctable:User, lookup:boolean=true) {
+    this.correctable = correctable;
+    this.lookup = lookup;
+  }
+
+  public correct = async (corrected:User):Promise<boolean> => {
+    try {
+      if( ! corrected) {
+        console.log(`No user provided`);
+        return false;
+      }
+      if(this.lookup) {
+        /**
+         * The provided correctable user probably just has the key(s), so go to the database to get the rest.
+         * NOTE: Make sure the default timestamp conversion to date objects is avoided - The upcoming update needs 
+         * them to be ISO strings.
+         */
+        const user = await UserCrud(this.correctable).read({ convertDates:false }) as User;
+        if( ! user) {
+          error(this.correctable, 'Lookup for user failed');
+          return false;
+        }
+        this.correctable = user;
+      }
+
+      const { correctable, correctable: { email:old_email, phone_number:old_phone_number }, mergeUsers } = this;
+      const { email:new_email, phone_number:new_phone_number, entity_id, role, delegate } = corrected;
+
+      const fldChanged = (fldname:UserFields):boolean => {
+        const old = correctable[fldname];
+        const _new = corrected[fldname];
+        return (_new && _new != old) as boolean;
+      };
+
+      const delegateFldChanged = (fldname:DelegateFields):boolean => {
+        const old = correctable.delegate ? correctable.delegate[fldname] : undefined;
+        const _new = delegate ? delegate[fldname] : undefined;
+        if(old && ! _new) return true;
+        if(_new && ! old) return true;
+        return (_new && _new != old) as boolean;
+      }
+
+      const newEmail = () => fldChanged(UserFields.email);
+      const newPhone = () => fldChanged(UserFields.phone_number);
+      const delegateChanged = () => {
+        return delegateFldChanged(DelegateFields.fullname) || delegateFldChanged(DelegateFields.title)
+          || delegateFldChanged(DelegateFields.email) || delegateFldChanged(DelegateFields.phone_number);
+      }
+      const otherChanges = () => fldChanged(UserFields.fullname) || fldChanged(UserFields.title) || delegateChanged();    
+    
+      if(newEmail()) {
+        const original = { email: { propname:'email', value:old_email } } as CognitoStandardAttributes;
+        const updated = { email: { propname:'email', value:new_email } } as CognitoStandardAttributes;
+        // Have the new account inherit the old phone number 
+        updated.phoneNumber = { propname:'phone_number', value:old_phone_number, verified:true}
+
+        const userAccount = await UserAccount.getInstance(original, role);
+
+        // Create a new user account in cognito and delete the old one.
+        const userType:UserType|undefined = await userAccount.replaceWith(updated);
+
+        // Obtain the sub value of the newly created user account.
+        const { Username:sub } = userType ?? {}
+        if( ! sub) {
+          let msg = userAccount.getMessage();
+          this.message = msg ? msg : `Error encountered while replacing ${old_email} with ${new_email}: ${msg}`;
+          return false;
+        }
+
+        // Carry over any fields from the old user that do not exist in the new user.
+        corrected = mergeUsers(correctable, corrected);
+
+        // Give the new consenter the sub from the corresponding new cognito user account
+        corrected.sub = sub;
+
+        // Delete the old user from the database.
+        await UserCrud(correctable).Delete();
+
+        // Create a new user in the database with the new email address.
+        await UserCrud(corrected).update();
+      }
+      else if(newPhone()) {
+        const original = { email: { propname:'email', value:old_email } } as CognitoStandardAttributes;
+        const updated = { email: { propname:'email', value:new_email } } as CognitoStandardAttributes;
+        original.phoneNumber = { propname:'phone_number', value:old_phone_number};
+        updated.phoneNumber = { propname:'phone_number', value:new_phone_number};
+
+        const userAccount = await UserAccount.getInstance(original, role);
+
+        // Update phone_number in place inside the existing cognito user account. This requires it to be configured as mutable.
+        await userAccount.update(updated);
+        if( ! userAccount.ok()) {
+          this.message = userAccount.getMessage();
+          return false;
+        }
+
+        // Carry over any fields from the old user that do not exist in the new user.
+        corrected = mergeUsers(correctable, corrected);
+
+        // Pass on any updates to the user to the corresponding database record.
+        await UserCrud(corrected).update(correctable, true); 
+      }
+      else if(otherChanges()) {
+        // Carry over any fields from the old user that do not exist in the new user.
+        corrected = mergeUsers(correctable, corrected);
+
+        // Pass on any updates to the user to the corresponding database record.
+        await UserCrud(corrected).update(correctable, true);
+      }
+      else {
+        // Huh? If neither the email, phone, fullname or title has changed, then there ARE NO changes.
+        this.message = `INVALID STATE: Correction triggered for ${old_email}, but no changes detected.`;
+        log(this.message);
+        return false;
+      }
+
+      return true;
+    }
+    catch(e:any) {
+      log(e);
+      this.message = e.message;
+      return false;
+    }
+  }
+
+
+  /**
+   * With the exception of the email field, apply all attributes from the source user to
+   * the corresponding attributes of the target user if those target attributes are not already set.
+   * @param source 
+   * @param target 
+   * @returns 
+   */
+  private mergeUsers = (source:User, target:User):User => {
+    let fld: keyof typeof UserFields;
+    const { role, email, delegate } = UserFields;
+    for(fld in UserFields) {
+      if( ! source[fld]) continue;
+      switch(fld) {
+        case email:
+          continue;
+        case delegate:
+          if( ! target[delegate]) {
+            // Absense of a delegate in the target user is an explicit signal to remove the delegate if it exist at the source.
+            continue;
+          }
+        default:
+          if( ! target[fld]) {
+            if(fld == role) {
+              target[role] = source[role] as Roles;
+            }
+            else {
+              target[fld] = source[fld] as any;
+            }
+          }
+          break;
+      }
+    }
+
+    return target;
+  }
+
+  public getMessage = () => {
+    return this.message;
+  }
+}
+
+
+
+
+/**
+ * RUN MANUALLY:
+ */
+const { argv:args } = process;
+if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/functions/re-admin/Correction.ts')) {
+
+  const correctionScope = {
+    phone: true,
+    name: true,
+    email: true,
+  };
+
+  (async () => {
+
+    // Get context variables
+    const context:IContext = await require('../../../../contexts/context.json');
+    const { STACK_ID, ACCOUNT, REGION, TAGS: { Landscape }} = context;
+    const prefix = `${STACK_ID}-${Landscape}`;
+
+    // Set the environment variables
+    process.env.REGION = REGION;
+    process.env.PREFIX = prefix;
+    process.env.DEBUG = 'true';
+
+    const email = 'asp2.random.edu@warhen.work';
+    const correctable = (await UserCrud({ email } as User).read({ convertDates:false }) as User[])[0];
+    const corrected = Object.assign({}, correctable);
+    let { fullname='my full name', entity_id } = correctable;
+
+    if(correctionScope.name) {
+      // Append an incrementing counter to the fullname field (makes multiple consecutive corrections easy). 
+      const regex = /\x20+\(Corrected\x20+\d+\)$/i;
+      const parts = fullname.split(regex);
+      let idx = 1;
+      if(parts.length > 1) {
+        const suffix = regex.exec(fullname)![0];
+        idx = parseInt(/\d+/.exec(suffix)![0]) + 1;      
+      }
+      corrected.fullname = `${parts[0]} (Corrected ${idx})`;   
+    }
+
+    if(correctionScope.phone) {
+      // Correct the phone number to some randomly generated value that will pass validation checks.
+      const randomPhone = `+1617${/\d{7}$/.exec(`${new Date().getTime()}`)![0]}`;
+      corrected.phone_number = randomPhone;
+    }
+
+    if(correctionScope.email) {
+      // Set the cloudfront domain as an environment variable
+      const cloudfrontDomain = await lookupCloudfrontDomain(Landscape);
+      process.env.CLOUDFRONT_DOMAIN = cloudfrontDomain;
+
+      // Set the ARN for the stale entity vacancy handler
+      const { HandleStaleEntityVacancy } = DelayedExecutions;
+      const staleFuncName = `${prefix}-${HandleStaleEntityVacancy.coreName}`;
+      process.env[HandleStaleEntityVacancy.targetArnEnvVarName] = `arn:aws:lambda:${REGION}:${ACCOUNT}:function:${staleFuncName}`
+      
+      // Set the new email address
+      corrected.email = 'asp1.random.edu@warhen.work';
+    }
+
+    // Remove the firstname field from the corrections (should make no difference to the output form)
+    delete corrected.title;
+
+    // Execute the update
+    await new EntityRepToCorrect({ email, entity_id } as User).correct(corrected);
+
+    log('Update complete.');
+  })();
+}

--- a/lib/lambda/functions/re-admin/Correction.ts
+++ b/lib/lambda/functions/re-admin/Correction.ts
@@ -30,7 +30,7 @@ export class EntityRepToCorrect {
          * NOTE: Make sure the default timestamp conversion to date objects is avoided - The upcoming update needs 
          * them to be ISO strings.
          */
-        const user = await UserCrud(this.correctable).read({ convertDates:false }) as User;
+        const user = await UserCrud({ userinfo: this.correctable }).read({ convertDates:false }) as User;
         if( ! user) {
           error(this.correctable, 'Lookup for user failed');
           return false;
@@ -89,10 +89,10 @@ export class EntityRepToCorrect {
         corrected.sub = sub;
 
         // Delete the old user from the database.
-        await UserCrud(correctable).Delete();
+        await UserCrud({ userinfo: correctable }).Delete();
 
         // Create a new user in the database with the new email address.
-        await UserCrud(corrected).update();
+        await UserCrud({ userinfo: corrected }).update();
       }
       else if(newPhone()) {
         const original = { email: { propname:'email', value:old_email } } as CognitoStandardAttributes;
@@ -113,14 +113,14 @@ export class EntityRepToCorrect {
         corrected = mergeUsers(correctable, corrected);
 
         // Pass on any updates to the user to the corresponding database record.
-        await UserCrud(corrected).update(correctable, true); 
+        await UserCrud({ userinfo: corrected, removableDelegate:true }).update(correctable, true); 
       }
       else if(otherChanges()) {
         // Carry over any fields from the old user that do not exist in the new user.
         corrected = mergeUsers(correctable, corrected);
 
         // Pass on any updates to the user to the corresponding database record.
-        await UserCrud(corrected).update(correctable, true);
+        await UserCrud({ userinfo: corrected, removableDelegate:true }).update(correctable, true);
       }
       else {
         // Huh? If neither the email, phone, fullname or title has changed, then there ARE NO changes.
@@ -208,7 +208,7 @@ if(args.length > 2 && args[2].replace(/\\/g, '/').endsWith('lib/lambda/functions
     process.env.DEBUG = 'true';
 
     const email = 'asp2.random.edu@warhen.work';
-    const correctable = (await UserCrud({ email } as User).read({ convertDates:false }) as User[])[0];
+    const correctable = (await UserCrud({ userinfo: { email } as User }).read({ convertDates:false }) as User[])[0];
     const corrected = Object.assign({}, correctable);
     let { fullname='my full name', entity_id } = correctable;
 

--- a/lib/lambda/functions/sys-admin/SysAdminUser.ts
+++ b/lib/lambda/functions/sys-admin/SysAdminUser.ts
@@ -11,7 +11,7 @@ import { InvitablePerson, InvitablePersonParms } from '../../_lib/invitation/Inv
 import { SignupLink } from '../../_lib/invitation/SignupLink';
 import { debugLog, error, errorResponse, invalidResponse, log, lookupCloudfrontDomain, okResponse } from "../../Utils";
 import { EntityToDemolish } from '../authorized-individual/Demolition';
-import { Task as ReAdminTasks, createEntity, deactivateEntity, inviteUsers, lookupEntity, retractInvitation, sendEntityRegistrationForm, updateEntity } from '../re-admin/ReAdminUser';
+import { Task as ReAdminTasks, correctUser, createEntity, deactivateEntity, inviteUsers, lookupEntity, retractInvitation, sendEntityRegistrationForm, updateEntity } from '../re-admin/ReAdminUser';
 import { DynamoDbTableOutput } from './DynamoDbTableOutput';
 import { HtmlTableView } from './view/HtmlTableView';
 
@@ -75,6 +75,8 @@ export const handler = async (event:any):Promise<LambdaProxyIntegrationResponse>
           return await retractInvitation(parameters.code);
         case ReAdminTasks.SEND_REGISTRATION:
            return await sendEntityRegistrationForm({ email, role, termsHref, loginHref });
+        case ReAdminTasks.CORRECTION:
+          return await correctUser(parameters);
         case ReAdminTasks.PING:
           return okResponse('Ping!', parameters);
         case Task.REPLACE_RE_ADMIN:

--- a/lib/role/AuthorizedIndividual.ts
+++ b/lib/role/AuthorizedIndividual.ts
@@ -102,12 +102,12 @@ export class LambdaFunction extends AbstractFunction {
           'EttAuthIndCognitoPolicy': new PolicyDocument({
             statements: [
               new PolicyStatement({
-                actions: [  'cognito-idp:List*'  ],
+                actions: [ 'cognito-idp:List*'  ],
                 resources: [ '*' ],
                 effect: Effect.ALLOW
               }),
               new PolicyStatement({
-                actions: [  'cognito-idp:AdminGet*', 'cognito-idp:AdminDeleteUser' ],
+                actions: [ 'cognito-idp:*' ],
                 resources: [ userPoolArn ],
                 effect: Effect.ALLOW
               })

--- a/lib/role/ReAdmin.ts
+++ b/lib/role/ReAdmin.ts
@@ -102,12 +102,12 @@ export class LambdaFunction extends AbstractFunction {
           'EttReAdminCognitoPolicy': new PolicyDocument({
             statements: [
               new PolicyStatement({
-                actions: [  'cognito-idp:List*'  ],
+                actions: [ 'cognito-idp:List*'  ],
                 resources: [ '*' ],
                 effect: Effect.ALLOW
               }),
               new PolicyStatement({
-                actions: [  'cognito-idp:AdminGet*', 'cognito-idp:AdminDeleteUser' ],
+                actions: [ 'cognito-idp:*' ],
                 resources: [ userPoolArn ],
                 effect: Effect.ALLOW
               })

--- a/lib/role/SysAdmin.ts
+++ b/lib/role/SysAdmin.ts
@@ -100,17 +100,12 @@ export class LambdaFunction extends AbstractFunction {
           'EttSysAdminCognitoPolicy': new PolicyDocument({
             statements: [
               new PolicyStatement({
-                actions: [  'cognito-idp:List*'  ],
+                actions: [ 'cognito-idp:List*'  ],
                 resources: [ '*' ],
                 effect: Effect.ALLOW
               }),
               new PolicyStatement({
-                actions: [  
-                  'cognito-idp:AdminGet*', 
-                  'cognito-idp:AdminCreateUser',
-                  'cognito-idp:AdminDeleteUser', 
-                  'cognito-idp:AdminSetUserPassword' 
-                ],
+                actions: [ 'cognito-idp:*' ],
                 resources: [ userPoolArn ],
                 effect: Effect.ALLOW
               })


### PR DESCRIPTION
This feature introduces a feature that ASP and AI users can use to update their own details.
The user can make any combination of changes all at the same time.
The impact of the updates fall into 3 categories:

1. **Email**
  This causes:
    - Deleting the users database record
    - Establishing a new database record for the user (with new email address)
    - Deleting the users cognito account (old email address)
    - Establishing a new cognito account (new email address)
    - Signing the user out of ETT
    - Sending a password reset email the user with a temporary password. When the user signs in with their new email address, they enter the temporary password, submit, and the cognito hosted UI presents another screen for entering a new password.
2. **Phone**
  This causes:
    - Updating the users cognito account with the new phone number
    - Updating the users database record with the new phone number
3. **Other**
  This results in the corresponding change to be applied to users database record.
  NOTE: If the request is submitted with all delegate fields (email, fullname, title, phone_number) blanked out, this is a signal to remove the delegate from the users database record altogether.

NOTE: Deleting the user and re-inviting them was originally discussed as the approach to take (instead of using a password reset), but this introduces undue complexity to the ASP front-end, where a special flag would need to accompany the invitation to signal that the ASP will not encounter the normal registration screen where they would be required to enter the name of the entity, as if they were creating it.